### PR TITLE
Prompt: Discard any input on ctrl+c or ctrl+u

### DIFF
--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -788,6 +788,10 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
                 m.input.push_back(CTRL_KEY('d'));
                 break;
             }
+        } else if (key == CTRL_KEY('c') || key == CTRL_KEY('u')) {
+            // Discard any input
+            m.input = std::string(1, key);
+            break;
         } else {
             switch (key) {
                 case Key::BACKSPACE:


### PR DESCRIPTION
In the prompt, instead of pushing back the `ctrl + d` key at the end of the input, I remove any previous input and push this key only.
Same for `ctrl + c`.

Please tell me what you think @certik :) This behavior sounds right to me but I am not sure this is the best way of doing it.