### PR TITLE
use pragma once instead of the include guard

### DIFF
--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -1,5 +1,4 @@
-#ifndef TERMINAL_H
-#define TERMINAL_H
+#pragma once
 
 /* This file is all platform independent, it contains the logic to build
  * the features that users need in a terminal application.
@@ -849,5 +848,3 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
 }
 
 } // namespace Term
-
-#endif // TERMINAL_H

--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -1,5 +1,4 @@
-#ifndef TERMINAL_BASE_H
-#define TERMINAL_BASE_H
+#pragma once
 
 /*
  * This file contains all the platform specific code regarding terminal input
@@ -269,5 +268,3 @@ public:
 };
 
 } // namespace Term
-
-#endif // TERMINAL_BASE_H


### PR DESCRIPTION
Hi!
I have searched a bit around (not on stack overflow, because the answers are sometimes wrong or don't provide sources) and found some differences. The official C++ reference [(here)](https://en.cppreference.com/w/cpp/preprocessor/impl) notes:

> #pragma once is a non-standard pragma that is supported by the vast majority of modern compilers. If it appears in a header file, it indicates that it is only to be parsed once, even if it is (directly or indirectly) included multiple times in the same source file.

and

> Unlike header guards, this pragma makes it impossible to erroneously use the same macro name in more than one file. On the other hand, since with #pragma once files are excluded based on their filesystem-level identity, this can't protect against including a header twice if it exists in more than one location in a project.

The wikipedia article [(here)](https://en.wikipedia.org/wiki/Pragma_once) notes:

> This approach minimally ensures that the contents of the include file are not seen more than once. This is more verbose, requires greater manual intervention, and is prone to programmer error as there are no mechanisms available to the compiler for prevention of accidental use of the same macro name in more than one file, which would result in only one of the files being included. Such errors are unlikely to remain undetected but can complicate the interpretation of a compiler error report. Since the pre-processor itself is responsible for handling #pragma once, the programmer cannot make errors which cause name clashes.

> In the absence of #include guards around #include directives, the use of #pragma once will improve compilation speed for some compilers since it is a higher-level mechanism; the compiler itself can compare filenames or inodes without having to invoke the C preprocessor to scan the header for #ifndef and #endif. Yet, since include guards appear very often and the overhead of opening files is significant, it is common for compilers to optimize the handling of include guards, making them as fast as #pragma once

The Wikipedia article also notes, that all compilers are supporting it. I personally see, that both options provide their pros and cons, so it's maybe more of a personal preference. I know though, Microsoft is referring `pragma once` and made it the default in Visual Studio community. Jetbrains for example is using the default include guard by default.

Greetings
Damon