### PR TITLE
Improved CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ if (NOT CMAKE_CXX_STANDARD)
         CACHE STRING "C++ standard" FORCE)
 endif ()
 
+option(CPPTERMINAL_BUILD_EXAMPLES "Set to ON to build examples" ON)
+option(CPPTERMINAL_ENABLE_INSTALL "Set to ON to enable install" ON)
+option(CPPTERMINAL_ENABLE_TESING "Set to ON to enable testing" ON)
+
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 add_library(cpp-terminal INTERFACE)
@@ -25,18 +29,23 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
         DESTINATION lib/${PROJECT_NAME}/cmake )
 
 
-enable_testing()
+if (CPPTERMINAL_ENABLE_TESING)
+    enable_testing()
 
-add_subdirectory(examples)
+    add_executable(test_terminal test_terminal.cpp)
+    target_link_libraries(test_terminal cpp-terminal)
+    add_test(test_terminal ${PROJECT_BINARY_DIR}/test_terminal)
+endif()
 
-add_executable(test_terminal test_terminal.cpp)
-target_link_libraries(test_terminal cpp-terminal)
-add_test(test_terminal ${PROJECT_BINARY_DIR}/test_terminal)
+if (CPPTERMINAL_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
 
-
-install(TARGETS cpp-terminal
-    RUNTIME DESTINATION bin
-    LIBRARY DESTINATION lib
-    ARCHIVE DESTINATION lib
-    PUBLIC_HEADER DESTINATION include/cpp-terminal
-)
+if (CPPTERMINAL_ENABLE_INSTALL)
+    install(TARGETS cpp-terminal
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
+        ARCHIVE DESTINATION lib
+        PUBLIC_HEADER DESTINATION include/cpp-terminal
+    )
+endif()

--- a/ci/citest.sh
+++ b/ci/citest.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-cmake -DCMAKE_INSTALL_PREFIX=`pwd`/inst .
+cmake -DCMAKE_INSTALL_PREFIX=./inst .
 cmake --build . --config Release
 cmake --install . --config Release
 ctest --output-on-failure

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -15,3 +15,29 @@ target_link_libraries(keys cpp-terminal)
 
 add_executable(colors colors.cpp)
 target_link_libraries(colors cpp-terminal)
+
+# enable warnings and set compile features
+foreach(target prompt kilo menu menu_window keys colors)
+        # Force Microsoft Visual Studio to decode sources files in UTF-8
+        if (MSVC)
+                target_compile_options(${target} PUBLIC "/utf-8")
+        endif()
+        # Add as many warning as possible:
+        if (WIN32)
+                if (MSVC)
+                        target_compile_options(${target} PRIVATE "/W4")
+                        target_compile_options(${target} PRIVATE "/WX")
+                        target_compile_options(${target} PRIVATE "/wd4244")
+                        target_compile_options(${target} PRIVATE "/wd4267")
+                        target_compile_options(${target} PRIVATE "/D_CRT_SECURE_NO_WARNINGS")
+                endif()
+                # Force Win32 to UNICODE
+                target_compile_definitions(${target} PRIVATE UNICODE _UNICODE)
+        else()
+                target_compile_options(${target} PRIVATE "-Wall")
+                target_compile_options(${target} PRIVATE "-Wextra")
+                target_compile_options(${target} PRIVATE "-pedantic")
+                target_compile_options(${target} PRIVATE "-Werror")
+                target_compile_options(${target} PRIVATE "-Wno-sign-compare")
+        endif()
+endforeach()

--- a/examples/kilo.cpp
+++ b/examples/kilo.cpp
@@ -690,7 +690,7 @@ void editorDrawMessageBar(std::string &ab) {
     ab.append(std::string(E.statusmsg, msglen));
 }
 
-void editorRefreshScreen(const Terminal &term) {
+void editorRefreshScreen(const Terminal) {
   editorScroll();
 
   std::string ab;


### PR DESCRIPTION
Hello,
it's me again, this time with some small changes in the cmake. I have added options to skip the building of the example projects to speed up compile time in xternal projects and remove the targets from visual studio codes target list. I have also enabled extended compile features on the example programs (it's not possible for the cpp-terminal target as it has only headers). Feel free to request changes!

Cheers!