### PR TITLE
24bit colors

### DIFF
--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -89,6 +89,14 @@ std::string color(T const value)
     return "\033[" + std::to_string(static_cast<int>(value)) + "m";
 }
 
+std::string color24(unsigned int red, unsigned int green, unsigned int blue, bool fg)
+{
+    if (fg)
+        return "\033[38;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
+    else
+        return "\033[48;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
+}
+
 inline void write(const std::string& s)
 {
     std::cout << s << std::flush;

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -84,9 +84,9 @@ enum class bgB {
 };
 
 template <typename T>
-std::string color(T const value)
+std::string color(T const& value)
 {
-    return "\033[" + std::to_string(static_cast<int>(value)) + "m";
+    return "\033[" + std::to_string(static_cast<unsigned int>(value)) + 'm';
 }
 
 std::string color24(unsigned int red, unsigned int green, unsigned int blue, bool fg)
@@ -548,16 +548,33 @@ class Window_24bit
         size_t x0, y0; // top-left corner of the window on the screen
         size_t w, h; // width and height of the window
         std::vector<char32_t> chars; // the characters in row first order
-        
         struct rgb {
             unsigned int r, g, b;
         };
-        
         std::vector<rgb> m_fg;
         std::vector<rgb> m_bg;
         std::vector<bool> m_fg_reset;
         std::vector<bool> m_bg_reset;
         std::vector<style> m_style;
+    
+        char32_t get_char(size_t x, size_t y) {
+            return chars[(y-1)*w+(x-1)];
+        }
+        bool get_fg_reset(size_t x, size_t y) {
+            return m_fg_reset[(y-1)*w+(x-1)];
+        }
+        bool get_bg_reset(size_t x, size_t y) {
+            return m_bg_reset[(y-1)*w+(x-1)];
+        }
+        rgb get_fg(size_t x, size_t y) {
+            return m_fg[(y-1)*w+(x-1)];
+        }
+        rgb get_bg(size_t x, size_t y) {
+            return m_bg[(y-1)*w+(x-1)];
+        }
+        style get_style(size_t x, size_t y) {
+            return m_style[(y-1)*w+(x-1)];
+        }
     public:
         Window_24bit(size_t x0, size_t y0, size_t w, size_t h)
             : x0{x0}, y0{y0}, w{w}, h{h}, chars(w*h, ' '),
@@ -565,16 +582,8 @@ class Window_24bit
               m_fg_reset(w*h, true), m_bg_reset(w*h, true),
               m_style(w*h, style::reset) {};
 
-        char32_t get_char(size_t x, size_t y) {
-            return chars[(y-1)*w+(x-1)];
-        }
-
         void set_char(size_t x, size_t y, char32_t c) {
             chars[(y-1)*w+(x-1)] = c;
-        }
-
-        bool get_fg_reset(size_t x, size_t y) {
-            return m_fg_reset[(y-1)*w+(x-1)];
         }
 
         void set_fg_reset(size_t x, size_t y) {
@@ -582,17 +591,9 @@ class Window_24bit
             m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
         }
 
-        bool get_bg_reset(size_t x, size_t y) {
-            return m_bg_reset[(y-1)*w+(x-1)];
-        }
-
         void set_bg_reset(size_t x, size_t y) {
             m_bg_reset[(y-1)*w+(x-1)] = true;
             m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
-        }
-
-        rgb get_fg(size_t x, size_t y) {
-            return m_fg[(y-1)*w+(x-1)];
         }
 
         void set_fg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
@@ -600,17 +601,9 @@ class Window_24bit
             m_fg[(y-1)*w+(x-1)] = {r, g, b};
         }
 
-        rgb get_bg(size_t x, size_t y) {
-            return m_bg[(y-1)*w+(x-1)];
-        }
-
         void set_bg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
             m_bg_reset[(y-1)*w+(x-1)] = false;
             m_bg[(y-1)*w+(x-1)] = {r, g, b};
-        }
-
-        style get_style(size_t x, size_t y) {
-            return m_style[(y-1)*w+(x-1)];
         }
 
         void set_style(size_t x, size_t y, style c) {
@@ -805,38 +798,38 @@ private:
     std::vector<fg> m_fg;
     std::vector<bg> m_bg;
     std::vector<style> m_style;
-public:
-    Window(size_t x0, size_t y0, size_t w, size_t h)
-        : x0{x0}, y0{y0}, w{w}, h{h}, chars(w*h, ' '),
-          m_fg(w*h, fg::reset), m_bg(w*h, bg::reset),
-          m_style(w*h, style::reset) {}
-
     char32_t get_char(size_t x, size_t y) {
         return chars[(y-1)*w+(x-1)];
     }
-
-    void set_char(size_t x, size_t y, char32_t c) {
-        chars[(y-1)*w+(x-1)] = c;
-    }
-
+    
     fg get_fg(size_t x, size_t y) {
         return m_fg[(y-1)*w+(x-1)];
-    }
-
-    void set_fg(size_t x, size_t y, fg c) {
-        m_fg[(y-1)*w+(x-1)] = c;
     }
 
     bg get_bg(size_t x, size_t y) {
         return m_bg[(y-1)*w+(x-1)];
     }
 
-    void set_bg(size_t x, size_t y, bg c) {
-        m_bg[(y-1)*w+(x-1)] = c;
-    }
-
     style get_style(size_t x, size_t y) {
         return m_style[(y-1)*w+(x-1)];
+    }
+
+public:
+    Window(size_t x0, size_t y0, size_t w, size_t h)
+        : x0{x0}, y0{y0}, w{w}, h{h}, chars(w*h, ' '),
+          m_fg(w*h, fg::reset), m_bg(w*h, bg::reset),
+          m_style(w*h, style::reset) {}
+
+    void set_char(size_t x, size_t y, char32_t c) {
+        chars[(y-1)*w+(x-1)] = c;
+    }
+
+    void set_fg(size_t x, size_t y, fg c) {
+        m_fg[(y-1)*w+(x-1)] = c;
+    }
+
+    void set_bg(size_t x, size_t y, bg c) {
+        m_bg[(y-1)*w+(x-1)] = c;
     }
 
     void set_style(size_t x, size_t y, style c) {

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -542,6 +542,247 @@ inline std::string utf32_to_utf8(const std::u32string &s)
 }
 
 
+class Window_24bit
+{
+    private:
+        size_t x0, y0; // top-left corner of the window on the screen
+        size_t w, h; // width and height of the window
+        std::vector<char32_t> chars; // the characters in row first order
+        
+        struct rgb {
+            unsigned int r, g, b;
+        };
+        
+        std::vector<rgb> m_fg;
+        std::vector<rgb> m_bg;
+        std::vector<bool> m_fg_reset;
+        std::vector<bool> m_bg_reset;
+        std::vector<style> m_style;
+    public:
+        Window_24bit(size_t x0, size_t y0, size_t w, size_t h)
+            : x0{x0}, y0{y0}, w{w}, h{h}, chars(w*h, ' '),
+              m_fg(w*h, {0,0,0}), m_bg(w*h, {0,0,0}),
+              m_fg_reset(w*h, true), m_bg_reset(w*h, true),
+              m_style(w*h, style::reset) {};
+
+        char32_t get_char(size_t x, size_t y) {
+            return chars[(y-1)*w+(x-1)];
+        }
+
+        void set_char(size_t x, size_t y, char32_t c) {
+            chars[(y-1)*w+(x-1)] = c;
+        }
+
+        bool get_fg_reset(size_t x, size_t y) {
+            return m_fg_reset[(y-1)*w+(x-1)];
+        }
+
+        void set_fg_reset(size_t x, size_t y) {
+            m_fg_reset[(y-1)*w+(x-1)] = true;
+            m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
+        }
+
+        bool get_bg_reset(size_t x, size_t y) {
+            return m_bg_reset[(y-1)*w+(x-1)];
+        }
+
+        void set_bg_reset(size_t x, size_t y) {
+            m_bg_reset[(y-1)*w+(x-1)] = true;
+            m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
+        }
+
+        rgb get_fg(size_t x, size_t y) {
+            return m_fg[(y-1)*w+(x-1)];
+        }
+
+        void set_fg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
+            m_fg_reset[(y-1)*w+(x-1)] = false;
+            m_fg[(y-1)*w+(x-1)] = {r, g, b};
+        }
+
+        rgb get_bg(size_t x, size_t y) {
+            return m_bg[(y-1)*w+(x-1)];
+        }
+
+        void set_bg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
+            m_bg_reset[(y-1)*w+(x-1)] = false;
+            m_bg[(y-1)*w+(x-1)] = {r, g, b};
+        }
+
+        style get_style(size_t x, size_t y) {
+            return m_style[(y-1)*w+(x-1)];
+        }
+
+        void set_style(size_t x, size_t y, style c) {
+            m_style[(y-1)*w+(x-1)] = c;
+        }
+
+        void print_str(int x, int y, const std::string &s) {
+            std::u32string s2 = utf8_to_utf32(s);
+            for (size_t i=0; i < s2.size(); i++) {
+                size_t xpos = x+i;
+                if (xpos < w) {
+                    set_char(xpos, y, s2[i]);
+                } else {
+                    // String is out of the window
+                    return;
+                }
+            }
+        }
+
+        void fill_fg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
+            for (int j=y1; j <= y2; j++) {
+                for (int i=x1; i <= x2; i++) {
+                    set_fg(i, j, r, g, b);
+                }
+            }
+        }
+
+        void fill_bg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
+            for (int j=y1; j <= y2; j++) {
+                for (int i=x1; i <= x2; i++) {
+                    set_bg(i, j, r, g, b);
+                }
+            }
+        }
+
+        void fill_style(int x1, int y1, int x2, int y2, style color) {
+            for (int j=y1; j <= y2; j++) {
+                for (int i=x1; i <= x2; i++) {
+                    set_style(i, j, color);
+                }
+            }
+        }
+
+        void print_border(bool unicode=true) {
+            print_rect(1, 1, w, h, unicode);
+        }
+
+        void print_rect(size_t x1, size_t y1, size_t x2, size_t y2,
+                        bool unicode = true) {
+          std::u32string border = utf8_to_utf32("│─┌┐└┘");
+          if (unicode) {
+            for (size_t j = y1 + 1; j <= y2 - 1; j++) {
+              set_char(x1, j, border[0]);
+              set_char(x2, j, border[0]);
+            }
+            for (size_t i = x1 + 1; i <= x2 - 1; i++) {
+              set_char(i, y1, border[1]);
+              set_char(i, y2, border[1]);
+            }
+            set_char(x1, y1, border[2]);
+            set_char(x2, y1, border[3]);
+            set_char(x1, y2, border[4]);
+            set_char(x2, y2, border[5]);
+          } else {
+            for (size_t j = y1 + 1; j <= y2 - 1; j++) {
+              set_char(x1, j, '|');
+              set_char(x2, j, '|');
+            }
+            for (size_t i = x1 + 1; i <= x2 - 1; i++) {
+              set_char(i, y1, '-');
+              set_char(i, y2, '-');
+            }
+            set_char(x1, y1, '+');
+            set_char(x2, y1, '+');
+            set_char(x1, y2, '+');
+            set_char(x2, y2, '+');
+          }
+        }
+
+        void clear() {
+            for (size_t j=1; j <= h; j++) {
+                for (size_t i=1; i <= w; i++) {
+                    set_char(i, j, ' ');
+                    set_fg_reset(i, j);
+                    set_bg_reset(i, j);
+                    set_style(i, j, style::reset);
+                }
+            }
+        }
+        static bool rgb_equal(rgb& rgb_one, rgb rgb_two) {
+            return rgb_one.r == rgb_two.r &&
+                   rgb_one.b == rgb_two.b &&
+                   rgb_one.g == rgb_two.g;
+        }
+
+        std::string render() {
+            std::string out;
+            out.append(cursor_off());
+            rgb current_fg = {256, 256, 256};
+            rgb current_bg =  {256, 256, 256};
+            bool current_fg_reset = true;
+            bool current_bg_reset = true;
+            style current_style = style::reset;
+            for (size_t j=1; j <= h; j++) {
+                out.append(move_cursor(y0+j-1, x0));
+                for (size_t i=1; i <= w; i++) {
+                    bool update_fg = false;
+                    bool update_bg = false;
+                    bool update_fg_reset = false;
+                    bool update_bg_reset = false;
+                    bool update_style = false;
+                    if (current_fg_reset != get_fg_reset(i, j)) {
+                        current_fg_reset = get_fg_reset(i, j);
+                        if (current_fg_reset)
+                            update_fg_reset = true;
+                            current_fg = {256, 256, 256};
+                    }
+                    if (current_bg_reset != get_bg_reset(i, j)) {
+                        current_bg_reset = get_bg_reset(i, j);
+                        if (current_bg_reset)
+                            update_bg_reset = true;
+                            current_bg = {256, 256, 256};
+                    }
+
+                    if (current_fg_reset == false) {
+                        if (!rgb_equal(current_fg, get_fg(i, j))) {
+                            current_fg = get_fg(i, j);
+                            update_fg = true;
+                        }
+                    }
+
+                    if (current_fg_reset == false) {
+                        if (!rgb_equal(current_bg, get_bg(i, j))) {
+                            current_bg = get_bg(i, j);
+                            update_bg = true;
+                        }
+                    }
+
+                    if (current_style != get_style(i,j)) {
+                        current_style = get_style(i,j);
+                        update_style = true;
+                        if (current_style == style::reset) {
+                            // style::reset resets fg and bg colors too, we have to
+                            // set them again if they are non-default, but if fg or
+                            // bg colors are reset, we do not update them, as
+                            // style::reset already did that.
+                            update_fg = (current_fg_reset == false);
+                            update_bg = (current_bg_reset == false);
+                        }
+                    }
+                    // Set style first, as style::reset will reset colors too
+                    if (update_style) out.append(color(get_style(i,j)));
+                    if (update_fg_reset) out.append(color(fg::reset));
+                    else if (update_fg) {
+                        rgb color_tmp = get_fg(i, j);
+                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, true));
+                    }
+                    if (update_bg_reset) out.append(color(bg::reset));
+                    else if (update_bg) {
+                        rgb color_tmp = get_bg(i, j);
+                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, false));
+                    }
+                    codepoint_to_utf8(out, get_char(i,j));
+                }
+            }
+            if (!current_fg_reset) out.append(color(fg::reset));
+            if (!current_bg_reset) out.append(color(bg::reset));
+            if (current_style != style::reset) out.append(color(style::reset));
+            out.append(cursor_on());
+            return out;
+        }
+};
 
 
 /* Represents a rectangular window, as a 2D array of characters and their

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -724,15 +724,17 @@ class Window_24bit
                     bool update_style = false;
                     if (current_fg_reset != get_fg_reset(i, j)) {
                         current_fg_reset = get_fg_reset(i, j);
-                        if (current_fg_reset)
+                        if (current_fg_reset) {
                             update_fg_reset = true;
                             current_fg = {256, 256, 256};
+                        }
                     }
                     if (current_bg_reset != get_bg_reset(i, j)) {
                         current_bg_reset = get_bg_reset(i, j);
-                        if (current_bg_reset)
+                        if (current_bg_reset) {
                             update_bg_reset = true;
                             current_bg = {256, 256, 256};
+                        }
                     }
 
                     if (current_fg_reset == false) {

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -10,6 +10,9 @@ target_link_libraries(menu cpp-terminal)
 add_executable(menu_window menu_window.cpp)
 target_link_libraries(menu_window cpp-terminal)
 
+add_executable(menu_window_24bit menu_window_24bit.cpp)
+target_link_libraries(menu_window_24bit cpp-terminal)
+
 add_executable(keys keys.cpp)
 target_link_libraries(keys cpp-terminal)
 

--- a/examples/colors.cpp
+++ b/examples/colors.cpp
@@ -3,6 +3,7 @@
 
 using Term::Terminal;
 using Term::color;
+using Term::color24;
 using Term::fg;
 using Term::bg;
 using Term::style;
@@ -26,6 +27,46 @@ int main() {
             + color(style::bold) + "bold text" + color(style::reset) + ".\n";
         text += "Unicode works too: originally written by Ondřej Čertík.";
         std::cout << text << std::endl;
+
+        std::string rgb_text = "Some Text in "
+            + color24(255, 0, 0, true) + 'R'
+            + color24(0, 255, 0, true) + 'G'
+            + color24(0, 0, 255, true) + 'B'
+            + color(fg::reset);
+
+        std::cout << rgb_text << std::endl;
+
+        std::cout << "A color chart: \n";
+
+        for (unsigned int i = 0; i <= 255; i += 3)
+        {
+            std::cout << color24(i, 0, 0, false)
+                      << " "
+                      << "\033[0m";
+        }
+        std::cout << "\n";
+        for (unsigned int i = 0; i <= 255; i += 3)
+        {
+            std::cout << color24(0, i, 0, false)
+                      << " "
+                      << "\033[0m";
+        }
+        std::cout << "\n";
+        for (unsigned int i = 0; i <= 255; i += 3)
+        {
+            std::cout << color24(0, 0, i, false)
+                      << " "
+                      << "\033[0m";
+        }
+        std::cout << "\n";
+        for (unsigned int i = 0; i <= 255; i += 3)
+        {
+            std::cout << color24(i, i, i, false)
+                      << " "
+                      << "\033[0m";
+        }
+        std::cout << "\n";
+
     } catch(const std::runtime_error& re) {
         std::cerr << "Runtime error: " << re.what() << std::endl;
         return 2;

--- a/examples/menu_window_24bit.cpp
+++ b/examples/menu_window_24bit.cpp
@@ -1,0 +1,73 @@
+#include <cpp-terminal/terminal.h>
+
+using Term::Terminal;
+using Term::fg;
+using Term::bg;
+using Term::style;
+using Term::Key;
+
+std::string render(Term::Window_24bit &scr, int rows, int cols,
+        int menuheight, int menuwidth, int menupos)
+{
+    scr.clear();
+    int menux0 = (cols - menuwidth) / 2+1;
+    int menuy0 = (rows - menuheight) / 2+1;
+    scr.print_rect(menux0, menuy0, menux0+menuwidth+1, menuy0+menuheight+1);
+
+    for (int i=1; i <= menuheight; i++) {
+        std::string s = std::to_string(i) + ": item";
+        scr.print_str(menux0+1, menuy0+i, s);
+        if (i == menupos) {
+            scr.fill_fg(menux0+1, menuy0+i, menux0+s.size(), menuy0+i, 184, 37, 0);
+            scr.fill_bg(menux0+1, menuy0+i, menux0+menuwidth, menuy0+i, 8, 9, 10);
+            scr.fill_style(menux0+1, menuy0+i, menux0+s.size(), menuy0+i, style::bold);
+        } else {
+            scr.fill_fg(menux0+1, menuy0+i, menux0+s.size(), menuy0+i, 5, 63, 97);
+            scr.fill_bg(menux0+1, menuy0+i, menux0+menuwidth, menuy0+i, 142, 166, 4);
+        }
+    }
+
+    int y = menuy0 + menuheight + 5;
+    scr.print_str(1, y,   "Selected item: " + std::to_string(menupos));
+    scr.print_str(1, y+1, "Menu width: " + std::to_string(menuwidth));
+    scr.print_str(1, y+2, "Menu height: " + std::to_string(menuheight));
+    scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ἐξήκοι");
+
+    return scr.render();
+}
+
+int main() {
+    try {
+        Terminal term(true, false);
+        term.save_screen();
+        int rows{}, cols{};
+        term.get_term_size(rows, cols);
+        int pos = 5;
+        int h = 10;
+        int w = 10;
+        bool on = true;
+        Term::Window_24bit scr(1, 1, cols, rows);
+        while (on) {
+            std::cout << render(scr, rows, cols, h, w, pos) << std::flush;
+            int key = term.read_key();
+            switch (key) {
+                case Key::ARROW_LEFT: if (w > 10) w--; break;
+                case Key::ARROW_RIGHT: if (w < cols-5) w++; break;
+                case Key::ARROW_UP: if (pos > 1) pos--; break;
+                case Key::ARROW_DOWN: if (pos < h) pos++; break;
+                case Key::HOME: pos=1; break;
+                case Key::END: pos=h; break;
+                case 'q':
+                case Key::ESC:
+                      on = false; break;
+            }
+        }
+    } catch(const std::runtime_error& re) {
+        std::cerr << "Runtime error: " << re.what() << std::endl;
+        return 2;
+    } catch(...) {
+        std::cerr << "Unknown error." << std::endl;
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
This pull-request adds `color24()`, a small addition to the `color()` function to use 24bit true color on supported terminals like discussed in #69.