### PR TITLE
Small usability improvements

### DIFF
--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -31,10 +31,11 @@ enum class style {
     italic = 3,
     underline = 4,
     blink = 5,
-    rblink = 6,
+    blink_rapid = 6,
     reversed = 7,
     conceal = 8,
-    crossed = 9
+    crossed = 9,
+    overline = 53
 };
 
 enum class fg {

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -84,12 +84,14 @@ static std::string color(T const& value)
     return "\033[" + std::to_string(static_cast<unsigned int>(value)) + 'm';
 }
 
-static std::string color24(unsigned int red, unsigned int green, unsigned int blue, bool fg)
+inline std::string color24_fg(unsigned int red, unsigned int green, unsigned int blue)
 {
-    if (fg)
-        return "\033[38;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
-    else
-        return "\033[48;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
+    return "\033[38;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
+}
+
+inline std::string color24_bg(unsigned int red, unsigned int green, unsigned int blue)
+{
+    return "\033[48;2;" + std::to_string(red) + ';' + std::to_string(green) + ';' + std::to_string(blue) + 'm';
 }
 
 inline void write(const std::string& s)
@@ -767,12 +769,12 @@ class Window_24bit
                     if (update_fg_reset) out.append(color(fg::reset));
                     else if (update_fg) {
                         rgb color_tmp = get_fg(i, j);
-                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, true));
+                        out.append(color24_fg(color_tmp.r, color_tmp.g, color_tmp.b));
                     }
                     if (update_bg_reset) out.append(color(bg::reset));
                     else if (update_bg) {
                         rgb color_tmp = get_bg(i, j);
-                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, false));
+                        out.append(color24_bg(color_tmp.r, color_tmp.g, color_tmp.b));
                     }
                     codepoint_to_utf8(out, get_char(i,j));
                 }

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -47,7 +47,15 @@ enum class fg {
     magenta = 35,
     cyan = 36,
     white = 37,
-    reset = 39
+    reset = 39,
+    gray = 90,
+    bright_red = 91,
+    bright_green = 92,
+    bright_yellow = 93,
+    bright_blue = 94,
+    bright_magenta = 95,
+    bright_cyan = 96,
+    bright_white = 97
 };
 
 enum class bg {
@@ -59,29 +67,15 @@ enum class bg {
     magenta = 45,
     cyan = 46,
     white = 47,
-    reset = 49
-};
-
-enum class fgB {
-    gray = 90,
-    red = 91,
-    green = 92,
-    yellow = 93,
-    blue = 94,
-    magenta = 95,
-    cyan = 96,
-    white = 97
-};
-
-enum class bgB {
+    reset = 49,
     gray = 100,
-    red = 101,
-    green = 102,
-    yellow = 103,
-    blue = 104,
-    magenta = 105,
-    cyan = 106,
-    white = 107
+    bright_red = 101,
+    bright_green = 102,
+    bright_yellow = 103,
+    bright_blue = 104,
+    bright_magenta = 105,
+    bright_cyan = 106,
+    bright_white = 107
 };
 
 template <typename T>

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -112,6 +112,17 @@ inline std::string cursor_on()
     return "\x1b[?25h";
 }
 
+inline std::string clear_screen()
+{
+    return "\033[2J";
+}
+
+// clears screen + scroll back buffer
+inline std::string clear_screen_buffer()
+{
+    return "\033[3J";
+}
+
 // If an attempt is made to move the cursor out of the window, the result is
 // undefined.
 inline std::string move_cursor(size_t row, size_t col)

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -46,7 +46,7 @@ enum class fg {
     blue = 34,
     magenta = 35,
     cyan = 36,
-    gray = 37,
+    white = 37,
     reset = 39
 };
 
@@ -58,30 +58,30 @@ enum class bg {
     blue = 44,
     magenta = 45,
     cyan = 46,
-    gray = 47,
+    white = 47,
     reset = 49
 };
 
 enum class fgB {
-    black = 90,
+    gray = 90,
     red = 91,
     green = 92,
     yellow = 93,
     blue = 94,
     magenta = 95,
     cyan = 96,
-    gray = 97
+    white = 97
 };
 
 enum class bgB {
-    black = 100,
+    gray = 100,
     red = 101,
     green = 102,
     yellow = 103,
     blue = 104,
     magenta = 105,
     cyan = 106,
-    gray = 107
+    white = 107
 };
 
 template <typename T>

--- a/examples/colors.cpp
+++ b/examples/colors.cpp
@@ -3,7 +3,8 @@
 
 using Term::Terminal;
 using Term::color;
-using Term::color24;
+using Term::color24_fg;
+using Term::color24_bg;
 using Term::fg;
 using Term::bg;
 using Term::style;
@@ -29,9 +30,9 @@ int main() {
         std::cout << text << std::endl;
 
         std::string rgb_text = "Some Text in "
-            + color24(255, 0, 0, true) + 'R'
-            + color24(0, 255, 0, true) + 'G'
-            + color24(0, 0, 255, true) + 'B'
+            + color24_fg(255, 0, 0) + 'R'
+            + color24_fg(0, 255, 0) + 'G'
+            + color24_fg(0, 0, 255) + 'B'
             + color(fg::reset);
 
         std::cout << rgb_text << std::endl;
@@ -40,28 +41,28 @@ int main() {
 
         for (unsigned int i = 0; i <= 255; i += 3)
         {
-            std::cout << color24(i, 0, 0, false)
+            std::cout << color24_bg(i, 0, 0)
                       << " "
                       << "\033[0m";
         }
         std::cout << "\n";
         for (unsigned int i = 0; i <= 255; i += 3)
         {
-            std::cout << color24(0, i, 0, false)
+            std::cout << color24_bg(0, i, 0)
                       << " "
                       << "\033[0m";
         }
         std::cout << "\n";
         for (unsigned int i = 0; i <= 255; i += 3)
         {
-            std::cout << color24(0, 0, i, false)
+            std::cout << color24_bg(0, 0, i)
                       << " "
                       << "\033[0m";
         }
         std::cout << "\n";
         for (unsigned int i = 0; i <= 255; i += 3)
         {
-            std::cout << color24(i, i, i, false)
+            std::cout << color24_bg(i, i, i)
                       << " "
                       << "\033[0m";
         }


### PR DESCRIPTION
This add some improvements and additions:
- added `clear_screen()` and `clear_screen_buffer()`
- renamed `style::rblink` to `style::blink_rapid`
- added `style::overline`
- moved bright colors into fg / bg because it's the same but bright
- renamed some colors as white is not grey but bright black is
- split `color24` to make is easier to read in code and to make it inline instead of static