### PR TITLE
Merge of LFortran cpp-terminal changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(cpp-terminal
         LANGUAGES CXX)
 
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11
+    set(CMAKE_CXX_STANDARD 17
         CACHE STRING "C++ standard" FORCE)
 endif ()
 configure_file(cpp-terminal/version.h.in cpp-terminal/version.h)

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -14,7 +14,7 @@
 
 
 #include <cpp-terminal/terminal_base.h>
-
+#include <functional>
 #include <chrono>
 #include <iostream>
 #include <string>
@@ -1037,44 +1037,103 @@ public:
     return out;
 };
 
+};
+
 // This model contains all the information about the state of the prompt in an
 // abstract way, irrespective of where or how it is rendered.
-struct Model
-{
+struct Model {
     std::string prompt_string; // The string to show as the prompt
-    std::string input; // The current input string in the prompt
+    std::vector<std::string> lines; // The current input string in the prompt as
+            // a vector of lines, without '\n' at the end.
     // The current cursor position in the "input" string, starting from (1,1)
-    size_t cursor_col{}, cursor_row{};
+    size_t cursor_col, cursor_row;
 };
 
-inline std::string render(const Model &m, int prompt_row, int term_cols)
-{
-    std::string out;
-    out = cursor_off();
-    out += move_cursor(prompt_row, 1) + m.prompt_string + m.input;
-    size_t last_col = m.prompt_string.size() + m.input.size();
-    for (size_t i=0; i < term_cols-last_col; i++) {
-        out.append(" ");
+std::string concat(const std::vector<std::string> &lines) {
+    std::string s;
+    for (auto &line: lines) {
+        s.append(line + "\n");
     }
-    out.append(move_cursor(prompt_row+m.cursor_row-1,
-        m.prompt_string.size() + m.cursor_col));
-    out.append(cursor_on());
-    return out;
-};
+    return s;
+}
 
-static std::vector<std::string> PROMPT_HISTORY;
+std::vector<std::string> split(const std::string &s) {
+    size_t j = 0;
+    std::vector<std::string> lines;
+    lines.push_back("");
+    if (s[s.size()-1] != '\n') throw std::runtime_error("\\n is required");
+    for (size_t i=0; i<s.size()-1; i++) {
+        if (s[i] == '\n') {
+            j++;
+            lines.push_back("");
+        } else {
+            lines[j].push_back(s[i]);
+        }
+    }
+    return lines;
+}
 
-// Create a prompt in a given terminal.
-inline std::string prompt(const Terminal &term, const std::string &prompt_string,
-        std::vector<std::string> &history = PROMPT_HISTORY)
-{
-    int row{}, col{};
-    term.get_cursor_position(row, col);
-    int rows{}, cols{};
-    term.get_term_size(rows, cols);
+char32_t U(const std::string &s) {
+    std::u32string s2 = Term::utf8_to_utf32(s);
+    if (s2.size() != 1) throw std::runtime_error("U(s): s not a codepoint.");
+    return s2[0];
+}
+
+void print_left_curly_bracket(Term::Window &scr, int x, int y1, int y2) {
+    int h = y2-y1+1;
+    if (h == 1) {
+        scr.set_char(x, y1, U("]"));
+    } else {
+        scr.set_char(x, y1, U("┐"));
+        for (int j=y1+1; j <= y2-1; j++) {
+            scr.set_char(x, j, U("│"));
+        }
+        scr.set_char(x, y2, U("┘"));
+    }
+}
+
+void render(Term::Window &scr, const Model &m, size_t cols) {
+    scr.clear();
+    print_left_curly_bracket(scr, cols, 1, m.lines.size());
+    scr.print_str(cols-6, m.lines.size(), std::to_string(m.cursor_row) + ","
+            + std::to_string(m.cursor_col));
+    for (size_t j=0; j < m.lines.size(); j++) {
+        if (j == 0) {
+            scr.print_str(1, j+1, m.prompt_string);
+            scr.fill_fg(1, j+1, m.prompt_string.size(), m.lines.size(),
+                Term::fg::green);
+            scr.fill_style(1, j+1, m.prompt_string.size(), m.lines.size(),
+                Term::style::bold);
+        } else {
+            for (size_t i=0; i < m.prompt_string.size()-1; i++) {
+                scr.set_char(i+1, j+1, '.');
+            }
+        }
+        scr.print_str(m.prompt_string.size()+1, j+1, m.lines[j]);
+    }
+    scr.set_cursor_pos(m.prompt_string.size() + m.cursor_col, m.cursor_row);
+}
+
+std::string prompt(const Terminal &term, const std::string &prompt_string,
+        std::vector<std::string> &history, std::function<bool(std::string)>
+        &iscomplete) {
+    int row, col;
+    bool term_attached = term.is_stdin_a_tty();
+    if (term_attached) {
+        term.get_cursor_position(row, col);
+    } else {
+        row = 1;
+        col = 1;
+    }
+    int rows, cols;
+    if (!term.get_term_size(rows, cols)) {
+        rows = 25;
+        cols = 80;
+    }
 
     Model m;
     m.prompt_string = prompt_string;
+    m.lines.push_back("");
     m.cursor_col = 1;
     m.cursor_row = 1;
 
@@ -1082,43 +1141,55 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
     // changes will be forgotten once a command is submitted.
     std::vector<std::string> hist = history;
     size_t history_pos = hist.size();
-    hist.push_back(m.input); // Push back empty input
+    hist.push_back(concat(m.lines)); // Push back empty input
 
-    int key{};
-    write(render(m, row, cols));
-    while ((key = term.read_key()) != Key::ENTER) {
+    Term::Window scr(cols, 1);
+    int key;
+    render(scr, m, cols);
+    std::cout << scr.render(1, row, term_attached) << std::flush;
+    bool not_complete = true;
+    while (not_complete) {
+        key = term.read_key();
         if (  (key >= 'a' && key <= 'z') ||
               (key >= 'A' && key <= 'Z') ||
               (!iscntrl(key) && key < 128)  ) {
-            std::string before = m.input.substr(0, m.cursor_col-1);
+            std::string before = m.lines[m.cursor_row-1].substr(0,
+                    m.cursor_col-1);
             std::string newchar; newchar.push_back(key);
-            std::string after = m.input.substr(m.cursor_col-1);
-            m.input = before + newchar + after;
+            std::string after = m.lines[m.cursor_row-1].substr(m.cursor_col-1);
+            m.lines[m.cursor_row-1] = before + newchar + after;
             m.cursor_col++;
         } else if (key == CTRL_KEY('d')) {
-            if (m.input.size() == 0) {
-                m.input.push_back(CTRL_KEY('d'));
-                break;
+            if (m.lines.size() == 1 && m.lines[m.cursor_row-1].size() == 0) {
+                m.lines[m.cursor_row-1].push_back(CTRL_KEY('d'));
+                std::cout << "\n" << std::flush;
+                history.push_back(m.lines[0]);
+                return m.lines[0];
             }
-        } else if (key == CTRL_KEY('c') || key == CTRL_KEY('u')) {
-            // Discard any input
-            m.input = std::string(1, key);
-            break;
         } else {
             switch (key) {
                 case Key::BACKSPACE:
                     if (m.cursor_col > 1) {
-                        std::string before = m.input.substr(0, m.cursor_col-2);
-                        std::string after = m.input.substr(m.cursor_col-1);
-                        m.input = before + after;
+                        std::string before = m.lines[m.cursor_row-1].substr(0,
+                                m.cursor_col-2);
+                        std::string after = m.lines[m.cursor_row-1]
+                                .substr(m.cursor_col-1);
+                        m.lines[m.cursor_row-1] = before + after;
                         m.cursor_col--;
+                    } else if (m.cursor_col == 1 && m.cursor_row > 1) {
+                        m.cursor_col = m.lines[m.cursor_row-2].size() + 1;
+                        m.lines[m.cursor_row-2] += m.lines[m.cursor_row-1];
+                        m.lines.erase(m.lines.begin() + m.cursor_row-1);
+                        m.cursor_row--;
                     }
                     break;
                 case Key::DEL:
-                    if (m.cursor_col <= m.input.size()) {
-                        std::string before = m.input.substr(0, m.cursor_col-1);
-                        std::string after = m.input.substr(m.cursor_col);
-                        m.input = before + after;
+                    if (m.cursor_col <= m.lines[m.cursor_row-1].size()) {
+                        std::string before = m.lines[m.cursor_row-1].substr(0,
+                                m.cursor_col-1);
+                        std::string after = m.lines[m.cursor_row-1]
+                                .substr(m.cursor_col);
+                        m.lines[m.cursor_row-1] = before + after;
                     }
                     break;
                 case Key::ARROW_LEFT:
@@ -1127,7 +1198,7 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
                     }
                     break;
                 case Key::ARROW_RIGHT:
-                    if (m.cursor_col <= m.input.size()) {
+                    if (m.cursor_col <= m.lines[m.cursor_row-1].size()) {
                         m.cursor_col++;
                     }
                     break;
@@ -1135,34 +1206,96 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
                     m.cursor_col = 1;
                     break;
                 case Key::END:
-                    m.cursor_col = m.input.size()+1;
+                    m.cursor_col = m.lines[m.cursor_row-1].size()+1;
                     break;
                 case Key::ARROW_UP:
-                    if (history_pos > 0) {
-                        hist[history_pos] = m.input;
-                        history_pos--;
-                        m.input = hist[history_pos];
-                        m.cursor_col = m.input.size()+1;
+                    if (m.cursor_row == 1) {
+                        if (history_pos > 0) {
+                            hist[history_pos] = concat(m.lines);
+                            history_pos--;
+                            m.lines = split(hist[history_pos]);
+                            m.cursor_row = m.lines.size();
+                            if (m.cursor_col>m.lines[m.cursor_row-1].size()+1) {
+                                m.cursor_col = m.lines[m.cursor_row-1].size()+1;
+                            }
+                            if (m.lines.size() > scr.get_h()) {
+                                scr.set_h(m.lines.size());
+                            }
+                        }
+                    } else {
+                        m.cursor_row--;
+                        if (m.cursor_col > m.lines[m.cursor_row-1].size()+1) {
+                            m.cursor_col = m.lines[m.cursor_row-1].size()+1;
+                        }
                     }
                     break;
                 case Key::ARROW_DOWN:
-                    if (history_pos < hist.size()-1) {
-                        hist[history_pos] = m.input;
-                        history_pos++;
-                        m.input = hist[history_pos];
-                        m.cursor_col = m.input.size()+1;
+                    if (m.cursor_row == m.lines.size()) {
+                        if (history_pos < hist.size()-1) {
+                            hist[history_pos] = concat(m.lines);
+                            history_pos++;
+                            m.lines = split(hist[history_pos]);
+                            m.cursor_row = 1;
+                            if (m.cursor_col>m.lines[m.cursor_row-1].size()+1) {
+                                m.cursor_col = m.lines[m.cursor_row-1].size()+1;
+                            }
+                            if (m.lines.size() > scr.get_h()) {
+                                scr.set_h(m.lines.size());
+                            }
+                        }
+                    } else {
+                        m.cursor_row++;
+                        if (m.cursor_col > m.lines[m.cursor_row-1].size()+1) {
+                            m.cursor_col = m.lines[m.cursor_row-1].size()+1;
+                        }
                     }
                     break;
+                case Key::ENTER:
+                    not_complete = !iscomplete(concat(m.lines));
+                    if (not_complete) {
+                        key = Key::ALT_ENTER;
+                    } else {
+                        break;
+                    }
+                    [[fallthrough]];
+                case ALT_KEY('n'):
+                case CTRL_KEY('n'):
+                case Key::ALT_ENTER:
+                    std::string before = m.lines[m.cursor_row-1].substr(0,
+                            m.cursor_col-1);
+                    std::string after = m.lines[m.cursor_row-1]
+                            .substr(m.cursor_col-1);
+                    m.lines[m.cursor_row-1] = before;
+                    if (m.cursor_row < m.lines.size()) {
+                        // Not at the bottom row, can't push back
+                        m.lines.insert(m.lines.begin() + m.cursor_row, after);
+                    } else {
+                        m.lines.push_back(after);
+                    }
+                    m.cursor_col = 1;
+                    m.cursor_row++;
+                    if (m.lines.size() > scr.get_h()) {
+                        scr.set_h(m.lines.size());
+                    }
             }
         }
-        write(render(m, row, cols));
+        render(scr, m, cols);
+        std::cout << scr.render(1, row, term_attached) << std::flush;
+        if (row+(int)scr.get_h()-1 > rows) {
+            row = rows - ((int)scr.get_h()-1);
+            std::cout << scr.render(1, row, term_attached) << std::flush;
+        }
     }
-    write("\n");
-    history.push_back(m.input);
-    return m.input;
+    // REPL currently supports pressing enter at any cursor position, so
+    // correctly draw if the user presses enter at a line other than the bottom
+    std::string line_skips;
+    for (size_t i=0; i <= m.lines.size() - m.cursor_row; i++){
+        line_skips += "\n";
+    }
+    std::cout << line_skips << std::flush;
+    history.push_back(concat(m.lines));
+    return concat(m.lines);
 }
-
-};
 
 }; // namespace Term
 

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -1331,7 +1331,6 @@ inline std::string prompt(const Terminal &term, const std::string &prompt_string
                         break;
                     }
                     [[fallthrough]];
-                case ALT_KEY('n'):
                 case CTRL_KEY('n'):
                 case Key::ALT_ENTER:
                     std::string before = m.lines[m.cursor_row-1].substr(0,

--- a/cpp-terminal/terminal.h
+++ b/cpp-terminal/terminal.h
@@ -15,7 +15,6 @@
 
 #include <cpp-terminal/terminal_base.h>
 #include <functional>
-#include <chrono>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -186,7 +185,7 @@ public:
         : BaseTerminal(enable_keyboard, disable_ctrl_c),
           restore_screen_{false} {}
 
-    virtual ~Terminal() {
+    ~Terminal() override {
         restore_screen();
     }
 
@@ -204,11 +203,6 @@ public:
         restore_screen_ = true;
         write("\033" "7");    // save current cursor position
         write("\033[?1049h"); // save screen
-    }
-
-    inline void write(const std::string& s) const
-    {
-        std::cout << s << std::flush;
     }
 
     // Waits for a key press, translates escape codes
@@ -364,8 +358,7 @@ public:
             switch (c) {
             case '\x09': // TAB
                 return Key::TAB;
-            case '\x0a': // LF
-                return Key::ENTER;
+            case '\x0a': // LF; falls-through
             case '\x0d': // CR
                 return Key::ENTER;
             case '\x7f': // DEL
@@ -436,15 +429,15 @@ public:
             explicit CursorOff(const Terminal& term)
                 : term{ term }
             {
-                term.write(cursor_off());
+                write(cursor_off());
             }
             ~CursorOff()
             {
-                term.write(cursor_on());
+                write(cursor_on());
             }
         };
         CursorOff cursor_off(*this);
-        int old_row, old_col;
+        int old_row{}, old_col{};
         get_cursor_position(old_row, old_col);
         write(move_cursor_right(999) + move_cursor_down(999));
         get_cursor_position(rows, cols);
@@ -521,9 +514,9 @@ inline std::u32string utf8_to_utf32(const std::string &s)
 {
     uint32_t codepoint{};
     uint8_t state=UTF8_ACCEPT;
-    std::u32string r;
-    for (size_t i=0; i < s.size(); i++) {
-        state = utf8_decode_step(state, s[i], &codepoint);
+    std::u32string r{};
+    for (char i : s) {
+        state = utf8_decode_step(state, i, &codepoint);
         if (state == UTF8_ACCEPT) {
             r.push_back(codepoint);
         }
@@ -541,249 +534,328 @@ inline std::u32string utf8_to_utf32(const std::string &s)
 // Converts an UTF32 string to UTF8.
 inline std::string utf32_to_utf8(const std::u32string &s)
 {
-    std::string r;
-    for (size_t i=0; i < s.size(); i++) {
-        codepoint_to_utf8(r, s[i]);
+    std::string r{};
+    for (char32_t i : s) {
+        codepoint_to_utf8(r, i);
     }
     return r;
 }
 
-
+/* Represents a rectangular window, as a 2D array of characters and their
+ * attributes. The render method can convert this internal representation to a
+ * string that when printed will show the Window on the screen.
+ *
+ * Note: the characters are represented by char32_t, representing their UTF-32
+ * code point. The natural way to represent a character in a terminal would be
+ * a "unicode grapheme cluster", but due to a lack of a good library for C++
+ * that could handle those, we simply use a Unicode code point as a character.
+ */
 class Window_24bit
 {
-    private:
-        size_t x0, y0; // top-left corner of the window on the screen
-        size_t w, h; // width and height of the window
-        std::vector<char32_t> chars; // the characters in row first order
-        struct rgb {
-            unsigned int r, g, b;
-        };
-        std::vector<rgb> m_fg;
-        std::vector<rgb> m_bg;
-        std::vector<bool> m_fg_reset;
-        std::vector<bool> m_bg_reset;
-        std::vector<style> m_style;
-    
-        char32_t get_char(size_t x, size_t y) {
-            return chars[(y-1)*w+(x-1)];
-        }
-        bool get_fg_reset(size_t x, size_t y) {
-            return m_fg_reset[(y-1)*w+(x-1)];
-        }
-        bool get_bg_reset(size_t x, size_t y) {
-            return m_bg_reset[(y-1)*w+(x-1)];
-        }
-        rgb get_fg(size_t x, size_t y) {
-            return m_fg[(y-1)*w+(x-1)];
-        }
-        rgb get_bg(size_t x, size_t y) {
-            return m_bg[(y-1)*w+(x-1)];
-        }
-        style get_style(size_t x, size_t y) {
-            return m_style[(y-1)*w+(x-1)];
-        }
-    public:
-        Window_24bit(size_t x0, size_t y0, size_t w, size_t h)
-            : x0{x0}, y0{y0}, w{w}, h{h}, chars(w*h, ' '),
-              m_fg(w*h, {0,0,0}), m_bg(w*h, {0,0,0}),
-              m_fg_reset(w*h, true), m_bg_reset(w*h, true),
-              m_style(w*h, style::reset) {};
+private:
+    size_t w, h; // width and height of the window
+    size_t cursor_x, cursor_y; // current cursor position
+    std::vector<char32_t> chars; // the characters in row first order
+    struct rgb {
+        unsigned int r, g, b;
+    };
+    std::vector<rgb> m_fg;
+    std::vector<rgb> m_bg;
+    std::vector<bool> m_fg_reset;
+    std::vector<bool> m_bg_reset;
+    std::vector<style> m_style;
 
-        void set_char(size_t x, size_t y, char32_t c) {
+    char32_t get_char(size_t x, size_t y) {
+        return chars[(y-1)*w+(x-1)];
+    }
+
+    bool get_fg_reset(size_t x, size_t y) {
+        return m_fg_reset[(y-1)*w+(x-1)];
+    }
+    bool get_bg_reset(size_t x, size_t y) {
+        return m_bg_reset[(y-1)*w+(x-1)];
+    }
+    rgb get_fg(size_t x, size_t y) {
+        return m_fg[(y-1)*w+(x-1)];
+    }
+    rgb get_bg(size_t x, size_t y) {
+        return m_bg[(y-1)*w+(x-1)];
+    }
+
+    style get_style(size_t x, size_t y) {
+        return m_style[(y-1)*w+(x-1)];
+    }
+
+public:
+    Window_24bit(size_t w, size_t h)
+        : w{w}, h{h}, cursor_x{1}, cursor_y{1}, chars(w*h, ' '),
+          m_fg(w*h, {0,0,0}), m_bg(w*h, {0,0,0}),
+          m_fg_reset(w*h, true), m_bg_reset(w*h, true),
+          m_style(w*h, style::reset) {}
+
+    size_t get_w() const {
+        return w;
+    }
+
+    size_t get_h() const {
+        return h;
+    }
+
+    void set_char(size_t x, size_t y, char32_t c) {
+        if (x >= 1 && y >= 1 && x <= w && y <= h) {
             chars[(y-1)*w+(x-1)] = c;
+        } else {
+            throw std::runtime_error("set_char(): (x,y) out of bounds");
         }
+    }
 
-        void set_fg_reset(size_t x, size_t y) {
-            m_fg_reset[(y-1)*w+(x-1)] = true;
-            m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
+    void set_fg_reset(size_t x, size_t y) {
+        m_fg_reset[(y-1)*w+(x-1)] = true;
+        m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
+    }
+    
+    void set_bg_reset(size_t x, size_t y) {
+        m_bg_reset[(y-1)*w+(x-1)] = true;
+        m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
+    }
+    
+    void set_fg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
+        m_fg_reset[(y-1)*w+(x-1)] = false;
+        m_fg[(y-1)*w+(x-1)] = {r, g, b};
+    }
+    
+    void set_bg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
+        m_bg_reset[(y-1)*w+(x-1)] = false;
+        m_bg[(y-1)*w+(x-1)] = {r, g, b};
+    }
+
+    void set_style(size_t x, size_t y, style c) {
+        m_style[(y-1)*w+(x-1)] = c;
+    }
+
+    void set_cursor_pos(int x, int y) {
+        cursor_x = x;
+        cursor_y = y;
+    }
+
+    void set_h(size_t new_h) {
+        if (new_h == h) {
+            return;
+        } else if (new_h > h) {
+            size_t dc = (new_h-h) * w;
+            chars.insert(chars.end(), dc, ' ');
+            m_fg_reset.insert(m_fg_reset.end(), dc, true);
+            m_bg_reset.insert(m_bg_reset.end(), dc, true);
+            m_fg.insert(m_fg.end(), dc, {0, 0, 0});
+            m_bg.insert(m_bg.end(), dc, {0, 0, 0});
+            m_style.insert(m_style.end(), dc, style::reset);
+            h = new_h;
+        } else {
+            throw std::runtime_error("Shrinking height not supported.");
         }
+    }
 
-        void set_bg_reset(size_t x, size_t y) {
-            m_bg_reset[(y-1)*w+(x-1)] = true;
-            m_fg[(y-1)*w+(x-1)] = {256, 256, 256};
-        }
-
-        void set_fg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
-            m_fg_reset[(y-1)*w+(x-1)] = false;
-            m_fg[(y-1)*w+(x-1)] = {r, g, b};
-        }
-
-        void set_bg(size_t x, size_t y, unsigned int r, unsigned int g, unsigned int b) {
-            m_bg_reset[(y-1)*w+(x-1)] = false;
-            m_bg[(y-1)*w+(x-1)] = {r, g, b};
-        }
-
-        void set_style(size_t x, size_t y, style c) {
-            m_style[(y-1)*w+(x-1)] = c;
-        }
-
-        void print_str(int x, int y, const std::string &s) {
-            std::u32string s2 = utf8_to_utf32(s);
-            for (size_t i=0; i < s2.size(); i++) {
-                size_t xpos = x+i;
-                if (xpos < w) {
-                    set_char(xpos, y, s2[i]);
+    void print_str(int x, int y, const std::string &s, int indent=0,
+            bool move_cursor=false) {
+        std::u32string s2 = utf8_to_utf32(s);
+        size_t xpos = x;
+        size_t ypos = y;
+        for (char32_t i : s2) {
+            if (i == U'\n') {
+                xpos = x+indent;
+                ypos++;
+                if (xpos <= w && ypos <= h) {
+                    for (int j=0; j < indent; j++) {
+                        set_char(x+j, ypos, '.');
+                    }
                 } else {
                     // String is out of the window
                     return;
                 }
-            }
-        }
-
-        void fill_fg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
-            for (int j=y1; j <= y2; j++) {
-                for (int i=x1; i <= x2; i++) {
-                    set_fg(i, j, r, g, b);
+            } else {
+                if (xpos <= w && ypos <= h) {
+                    set_char(xpos, y, i);
+                } else {
+                    // String is out of the window
+                    return;
                 }
+                xpos++;
             }
         }
+        if (move_cursor) {
+            cursor_x = xpos;
+            cursor_y = ypos;
+        }
+    }
 
-        void fill_bg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
-            for (int j=y1; j <= y2; j++) {
-                for (int i=x1; i <= x2; i++) {
-                    set_bg(i, j, r, g, b);
+    void fill_fg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
+        for (int j=y1; j <= y2; j++) {
+            for (int i=x1; i <= x2; i++) {
+                set_fg(i, j, r, g, b);
+            }
+        }
+    }
+
+    void fill_bg(int x1, int y1, int x2, int y2, unsigned int r, unsigned int g, unsigned int b) {
+        for (int j=y1; j <= y2; j++) {
+            for (int i=x1; i <= x2; i++) {
+                set_bg(i, j, r, g, b);
+            }
+        }
+    }
+
+    void fill_style(int x1, int y1, int x2, int y2, style color) {
+        for (int j=y1; j <= y2; j++) {
+            for (int i=x1; i <= x2; i++) {
+                set_style(i, j, color);
+            }
+        }
+    }
+
+    void print_border(bool unicode=true) {
+        print_rect(1, 1, w, h, unicode);
+    }
+
+    void print_rect(size_t x1, size_t y1, size_t x2, size_t y2,
+                    bool unicode = true) {
+      std::u32string border = utf8_to_utf32("│─┌┐└┘");
+      if (unicode) {
+        for (size_t j = y1 + 1; j <= y2 - 1; j++) {
+          set_char(x1, j, border[0]);
+          set_char(x2, j, border[0]);
+        }
+        for (size_t i = x1 + 1; i <= x2 - 1; i++) {
+          set_char(i, y1, border[1]);
+          set_char(i, y2, border[1]);
+        }
+        set_char(x1, y1, border[2]);
+        set_char(x2, y1, border[3]);
+        set_char(x1, y2, border[4]);
+        set_char(x2, y2, border[5]);
+      } else {
+        for (size_t j = y1 + 1; j <= y2 - 1; j++) {
+          set_char(x1, j, '|');
+          set_char(x2, j, '|');
+        }
+        for (size_t i = x1 + 1; i <= x2 - 1; i++) {
+          set_char(i, y1, '-');
+          set_char(i, y2, '-');
+        }
+        set_char(x1, y1, '+');
+        set_char(x2, y1, '+');
+        set_char(x1, y2, '+');
+        set_char(x2, y2, '+');
+      }
+    }
+
+    void clear() {
+        for (size_t j=1; j <= h; j++) {
+            for (size_t i=1; i <= w; i++) {
+                set_char(i, j, ' ');
+                set_fg_reset(i, j);
+                set_bg_reset(i, j);
+                set_style(i, j, style::reset);
+            }
+        }
+    }
+
+    static bool rgb_equal(rgb& rgb_one, rgb rgb_two) {
+        return rgb_one.r == rgb_two.r &&
+               rgb_one.b == rgb_two.b &&
+               rgb_one.g == rgb_two.g;
+    }
+
+    // TODO: add Window/Screen parameter here, to be used like this:
+    // old_scr = scr;
+    // scr.print_str(...)
+    // scr.render(1, 1, old_scr)
+    std::string render(int x0, int y0, bool term) {
+        std::string out;
+        if (term){
+          out.append(cursor_off());
+        }
+        rgb current_fg = {256, 256, 256};
+        rgb current_bg =  {256, 256, 256};
+        bool current_fg_reset = true;
+        bool current_bg_reset = true;
+        style current_style = style::reset;
+        for (size_t j=1; j <= h; j++) {
+            if (term){
+              out.append(move_cursor(y0+j-1, x0));
+            }
+            for (size_t i=1; i <= w; i++) {
+                bool update_fg = false;
+                bool update_bg = false;
+                bool update_fg_reset = false;
+                bool update_bg_reset = false;
+                bool update_style = false;
+                if (current_fg_reset != get_fg_reset(i, j)) {
+                    current_fg_reset = get_fg_reset(i, j);
+                    if (current_fg_reset) {
+                        update_fg_reset = true;
+                        current_fg = {256, 256, 256};
+                    }
                 }
-            }
-        }
-
-        void fill_style(int x1, int y1, int x2, int y2, style color) {
-            for (int j=y1; j <= y2; j++) {
-                for (int i=x1; i <= x2; i++) {
-                    set_style(i, j, color);
+                
+                if (current_bg_reset != get_bg_reset(i, j)) {
+                    current_bg_reset = get_bg_reset(i, j);
+                    if (current_bg_reset) {
+                        update_bg_reset = true;
+                        current_bg = {256, 256, 256};
+                    }
                 }
-            }
-        }
 
-        void print_border(bool unicode=true) {
-            print_rect(1, 1, w, h, unicode);
-        }
-
-        void print_rect(size_t x1, size_t y1, size_t x2, size_t y2,
-                        bool unicode = true) {
-          std::u32string border = utf8_to_utf32("│─┌┐└┘");
-          if (unicode) {
-            for (size_t j = y1 + 1; j <= y2 - 1; j++) {
-              set_char(x1, j, border[0]);
-              set_char(x2, j, border[0]);
-            }
-            for (size_t i = x1 + 1; i <= x2 - 1; i++) {
-              set_char(i, y1, border[1]);
-              set_char(i, y2, border[1]);
-            }
-            set_char(x1, y1, border[2]);
-            set_char(x2, y1, border[3]);
-            set_char(x1, y2, border[4]);
-            set_char(x2, y2, border[5]);
-          } else {
-            for (size_t j = y1 + 1; j <= y2 - 1; j++) {
-              set_char(x1, j, '|');
-              set_char(x2, j, '|');
-            }
-            for (size_t i = x1 + 1; i <= x2 - 1; i++) {
-              set_char(i, y1, '-');
-              set_char(i, y2, '-');
-            }
-            set_char(x1, y1, '+');
-            set_char(x2, y1, '+');
-            set_char(x1, y2, '+');
-            set_char(x2, y2, '+');
-          }
-        }
-
-        void clear() {
-            for (size_t j=1; j <= h; j++) {
-                for (size_t i=1; i <= w; i++) {
-                    set_char(i, j, ' ');
-                    set_fg_reset(i, j);
-                    set_bg_reset(i, j);
-                    set_style(i, j, style::reset);
+                if (current_fg_reset == false) {
+                    if (!rgb_equal(current_fg, get_fg(i, j))) {
+                        current_fg = get_fg(i, j);
+                        update_fg = true;
+                    }
                 }
-            }
-        }
-        static bool rgb_equal(rgb& rgb_one, rgb rgb_two) {
-            return rgb_one.r == rgb_two.r &&
-                   rgb_one.b == rgb_two.b &&
-                   rgb_one.g == rgb_two.g;
-        }
 
-        std::string render() {
-            std::string out;
-            out.append(cursor_off());
-            rgb current_fg = {256, 256, 256};
-            rgb current_bg =  {256, 256, 256};
-            bool current_fg_reset = true;
-            bool current_bg_reset = true;
-            style current_style = style::reset;
-            for (size_t j=1; j <= h; j++) {
-                out.append(move_cursor(y0+j-1, x0));
-                for (size_t i=1; i <= w; i++) {
-                    bool update_fg = false;
-                    bool update_bg = false;
-                    bool update_fg_reset = false;
-                    bool update_bg_reset = false;
-                    bool update_style = false;
-                    if (current_fg_reset != get_fg_reset(i, j)) {
-                        current_fg_reset = get_fg_reset(i, j);
-                        if (current_fg_reset) {
-                            update_fg_reset = true;
-                            current_fg = {256, 256, 256};
-                        }
+                if (current_fg_reset == false) {
+                    if (!rgb_equal(current_bg, get_bg(i, j))) {
+                        current_bg = get_bg(i, j);
+                        update_bg = true;
                     }
-                    if (current_bg_reset != get_bg_reset(i, j)) {
-                        current_bg_reset = get_bg_reset(i, j);
-                        if (current_bg_reset) {
-                            update_bg_reset = true;
-                            current_bg = {256, 256, 256};
-                        }
-                    }
-
-                    if (current_fg_reset == false) {
-                        if (!rgb_equal(current_fg, get_fg(i, j))) {
-                            current_fg = get_fg(i, j);
-                            update_fg = true;
-                        }
-                    }
-
-                    if (current_fg_reset == false) {
-                        if (!rgb_equal(current_bg, get_bg(i, j))) {
-                            current_bg = get_bg(i, j);
-                            update_bg = true;
-                        }
-                    }
-
-                    if (current_style != get_style(i,j)) {
-                        current_style = get_style(i,j);
-                        update_style = true;
-                        if (current_style == style::reset) {
-                            // style::reset resets fg and bg colors too, we have to
-                            // set them again if they are non-default, but if fg or
-                            // bg colors are reset, we do not update them, as
-                            // style::reset already did that.
-                            update_fg = (current_fg_reset == false);
-                            update_bg = (current_bg_reset == false);
-                        }
-                    }
-                    // Set style first, as style::reset will reset colors too
-                    if (update_style) out.append(color(get_style(i,j)));
-                    if (update_fg_reset) out.append(color(fg::reset));
-                    else if (update_fg) {
-                        rgb color_tmp = get_fg(i, j);
-                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, true));
-                    }
-                    if (update_bg_reset) out.append(color(bg::reset));
-                    else if (update_bg) {
-                        rgb color_tmp = get_bg(i, j);
-                        out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, false));
-                    }
-                    codepoint_to_utf8(out, get_char(i,j));
                 }
+                if (current_style != get_style(i,j)) {
+                    current_style = get_style(i,j);
+                    update_style = true;
+                    if (current_style == style::reset) {
+                        // style::reset resets fg and bg colors too, we have to
+                        // set them again if they are non-default, but if fg or
+                        // bg colors are reset, we do not update them, as
+                        // style::reset already did that.
+                        update_fg = (current_fg_reset == false);
+                        update_bg = (current_bg_reset == false);
+                    }
+                }
+                // Set style first, as style::reset will reset colors too
+                if (update_style) out.append(color(get_style(i,j)));
+                if (update_fg_reset) out.append(color(fg::reset));
+                else if (update_fg) {
+                    rgb color_tmp = get_fg(i, j);
+                    out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, true));
+                }
+                if (update_bg_reset) out.append(color(bg::reset));
+                else if (update_bg) {
+                    rgb color_tmp = get_bg(i, j);
+                    out.append(color24(color_tmp.r, color_tmp.g, color_tmp.b, false));
+                }
+                codepoint_to_utf8(out, get_char(i,j));
             }
-            if (!current_fg_reset) out.append(color(fg::reset));
-            if (!current_bg_reset) out.append(color(bg::reset));
-            if (current_style != style::reset) out.append(color(style::reset));
-            out.append(cursor_on());
-            return out;
+            if (j < h) out.append("\n");
         }
+        if (!current_fg_reset) out.append(color(fg::reset));
+        if (!current_bg_reset) out.append(color(bg::reset));
+        if (current_style != style::reset) out.append(color(style::reset));
+        if (term) {
+          out.append(move_cursor(y0+cursor_y-1, x0+cursor_x-1));
+          out.append(cursor_on());
+        }
+    return out;
+};
+
 };
 
 
@@ -805,14 +877,35 @@ private:
     std::vector<fg> m_fg;
     std::vector<bg> m_bg;
     std::vector<style> m_style;
+
+    char32_t get_char(size_t x, size_t y) {
+        return chars[(y-1)*w+(x-1)];
+    }
+
+    fg get_fg(size_t x, size_t y) {
+        return m_fg[(y-1)*w+(x-1)];
+    }
+
+    bg get_bg(size_t x, size_t y) {
+        return m_bg[(y-1)*w+(x-1)];
+    }
+
+    style get_style(size_t x, size_t y) {
+        return m_style[(y-1)*w+(x-1)];
+    }
+
 public:
     Window(size_t w, size_t h)
         : w{w}, h{h}, cursor_x{1}, cursor_y{1}, chars(w*h, ' '),
           m_fg(w*h, fg::reset), m_bg(w*h, bg::reset),
           m_style(w*h, style::reset) {}
 
-    char32_t get_char(size_t x, size_t y) {
-        return chars[(y-1)*w+(x-1)];
+    size_t get_w() const {
+        return w;
+    }
+
+    size_t get_h() const {
+        return h;
     }
 
     void set_char(size_t x, size_t y, char32_t c) {
@@ -823,24 +916,12 @@ public:
         }
     }
 
-    fg get_fg(size_t x, size_t y) {
-        return m_fg[(y-1)*w+(x-1)];
-    }
-
     void set_fg(size_t x, size_t y, fg c) {
         m_fg[(y-1)*w+(x-1)] = c;
     }
 
-    bg get_bg(size_t x, size_t y) {
-        return m_bg[(y-1)*w+(x-1)];
-    }
-
     void set_bg(size_t x, size_t y, bg c) {
         m_bg[(y-1)*w+(x-1)] = c;
-    }
-
-    style get_style(size_t x, size_t y) {
-        return m_style[(y-1)*w+(x-1)];
     }
 
     void set_style(size_t x, size_t y, style c) {
@@ -852,19 +933,11 @@ public:
         cursor_y = y;
     }
 
-    size_t get_w() {
-        return w;
-    }
-
-    size_t get_h() {
-        return h;
-    }
-
     void set_h(size_t new_h) {
         if (new_h == h) {
             return;
         } else if (new_h > h) {
-            int dc = (new_h-h) * w;
+            size_t dc = (new_h-h) * w;
             chars.insert(chars.end(), dc, ' ');
             m_fg.insert(m_fg.end(), dc, fg::reset);
             m_bg.insert(m_bg.end(), dc, bg::reset);
@@ -880,8 +953,8 @@ public:
         std::u32string s2 = utf8_to_utf32(s);
         size_t xpos = x;
         size_t ypos = y;
-        for (size_t i=0; i < s2.size(); i++) {
-            if (s2[i] == U'\n') {
+        for (char32_t i : s2) {
+            if (i == U'\n') {
                 xpos = x+indent;
                 ypos++;
                 if (xpos <= w && ypos <= h) {
@@ -894,7 +967,7 @@ public:
                 }
             } else {
                 if (xpos <= w && ypos <= h) {
-                    set_char(xpos, y, s2[i]);
+                    set_char(xpos, y, i);
                 } else {
                     // String is out of the window
                     return;
@@ -1046,7 +1119,7 @@ struct Model {
     std::vector<std::string> lines; // The current input string in the prompt as
             // a vector of lines, without '\n' at the end.
     // The current cursor position in the "input" string, starting from (1,1)
-    size_t cursor_col, cursor_row;
+    size_t cursor_col{}, cursor_row{};
 };
 
 std::string concat(const std::vector<std::string> &lines) {
@@ -1060,12 +1133,12 @@ std::string concat(const std::vector<std::string> &lines) {
 std::vector<std::string> split(const std::string &s) {
     size_t j = 0;
     std::vector<std::string> lines;
-    lines.push_back("");
+    lines.emplace_back("");
     if (s[s.size()-1] != '\n') throw std::runtime_error("\\n is required");
     for (size_t i=0; i<s.size()-1; i++) {
         if (s[i] == '\n') {
             j++;
-            lines.push_back("");
+            lines.emplace_back("");
         } else {
             lines[j].push_back(s[i]);
         }
@@ -1114,11 +1187,11 @@ void render(Term::Window &scr, const Model &m, size_t cols) {
     scr.set_cursor_pos(m.prompt_string.size() + m.cursor_col, m.cursor_row);
 }
 
-std::string prompt(const Terminal &term, const std::string &prompt_string,
+inline std::string prompt(const Terminal &term, const std::string &prompt_string,
         std::vector<std::string> &history, std::function<bool(std::string)>
         &iscomplete) {
     int row, col;
-    bool term_attached = term.is_stdin_a_tty();
+    bool term_attached = Terminal::is_stdin_a_tty();
     if (term_attached) {
         term.get_cursor_position(row, col);
     } else {
@@ -1133,7 +1206,7 @@ std::string prompt(const Terminal &term, const std::string &prompt_string,
 
     Model m;
     m.prompt_string = prompt_string;
-    m.lines.push_back("");
+    m.lines.emplace_back("");
     m.cursor_col = 1;
     m.cursor_row = 1;
 
@@ -1157,10 +1230,10 @@ std::string prompt(const Terminal &term, const std::string &prompt_string,
                     m.cursor_col-1);
             std::string newchar; newchar.push_back(key);
             std::string after = m.lines[m.cursor_row-1].substr(m.cursor_col-1);
-            m.lines[m.cursor_row-1] = before + newchar + after;
+            m.lines[m.cursor_row-1] = before += newchar += after;
             m.cursor_col++;
         } else if (key == CTRL_KEY('d')) {
-            if (m.lines.size() == 1 && m.lines[m.cursor_row-1].size() == 0) {
+            if (m.lines.size() == 1 && m.lines[m.cursor_row-1].empty()) {
                 m.lines[m.cursor_row-1].push_back(CTRL_KEY('d'));
                 std::cout << "\n" << std::flush;
                 history.push_back(m.lines[0]);
@@ -1297,6 +1370,6 @@ std::string prompt(const Terminal &term, const std::string &prompt_string,
     return concat(m.lines);
 }
 
-}; // namespace Term
+} // namespace Term
 
 #endif // TERMINAL_H

--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -13,6 +13,7 @@
 
 #ifdef _WIN32
 #    include <conio.h>
+#    define _WINSOCKAPI_
 #    include <windows.h>
 #    include <io.h>
 #else

--- a/cpp-terminal/terminal_base.h
+++ b/cpp-terminal/terminal_base.h
@@ -13,7 +13,6 @@
 
 #ifdef _WIN32
 #    include <conio.h>
-#    define _WINSOCKAPI_
 #    include <windows.h>
 #    include <io.h>
 #else

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -33,7 +33,7 @@ std::string render(Term::Window &scr, int rows, int cols,
     scr.print_str(1, y+2, "Menu height: " + std::to_string(menuheight));
     scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ἐξήκοι");
 
-    return scr.render();
+    return scr.render(1,1, true);
 }
 
 int main() {
@@ -46,7 +46,7 @@ int main() {
         int h = 10;
         int w = 10;
         bool on = true;
-        Term::Window scr(1, 1, cols, rows);
+        Term::Window scr(cols, rows);
         while (on) {
             std::cout << render(scr, rows, cols, h, w, pos) << std::flush;
             int key = term.read_key();

--- a/examples/menu_window_24bit.cpp
+++ b/examples/menu_window_24bit.cpp
@@ -33,7 +33,7 @@ std::string render(Term::Window_24bit &scr, int rows, int cols,
     scr.print_str(1, y+2, "Menu height: " + std::to_string(menuheight));
     scr.print_str(1, y+3, "Unicode test: Ondřej Čertík, ἐξήκοι");
 
-    return scr.render();
+    return scr.render(1, 1, true);
 }
 
 int main() {
@@ -46,7 +46,7 @@ int main() {
         int h = 10;
         int w = 10;
         bool on = true;
-        Term::Window_24bit scr(1, 1, cols, rows);
+        Term::Window_24bit scr(cols, rows);
         while (on) {
             std::cout << render(scr, rows, cols, h, w, pos) << std::flush;
             int key = term.read_key();

--- a/examples/prompt.cpp
+++ b/examples/prompt.cpp
@@ -8,7 +8,7 @@ using Term::Terminal;
 using Term::prompt;
 
 
-bool determine_completeness(std::string command)
+bool determine_completeness([[maybe_unused]] std::string command)
 {
     // Determine if the statement is complete
     bool complete;

--- a/examples/prompt.cpp
+++ b/examples/prompt.cpp
@@ -11,9 +11,12 @@ using Term::prompt;
 bool determine_completeness(std::string command)
 {
     // Determine if the statement is complete
-    // Get the tokens
     bool complete;
-    complete = true;
+    if (command.substr(command.size()-2, 1) == "\\"){
+        complete = false;
+    } else {
+        complete = true;
+    }
     return complete;
 }
 

--- a/examples/prompt.cpp
+++ b/examples/prompt.cpp
@@ -1,9 +1,21 @@
 #include <cpp-terminal/terminal.h>
 
 #include <vector>
+#include <functional>
+#include <string>
 
 using Term::Terminal;
 using Term::prompt;
+
+
+bool determine_completeness(std::string command)
+{
+    // Determine if the statement is complete
+    // Get the tokens
+    bool complete;
+    complete = true;
+    return complete;
+}
 
 
 int main() {
@@ -15,12 +27,13 @@ int main() {
         std::cout << "  * Features:" << std::endl;
         std::cout << "    - Editing (Keys: Left, Right, Home, End, Backspace)" << std::endl;
         std::cout << "    - History (Keys: Up, Down)" << std::endl;
+        std::cout << "    - Multi-line editing (use Alt-Enter to add a new line)" << std::endl;
         // TODO:
-        //std::cout << "    - Multi-line editing (use Alt-Enter to add a new line)" << std::endl;
         //std::cout << "    - Syntax highlighting" << std::endl;
         std::vector<std::string> history;
+        std::function<bool(std::string)> iscomplete = determine_completeness;
         while (true) {
-            std::string answer = prompt(term, "> ", history);
+            std::string answer = prompt(term, "> ", history, iscomplete);
             if (answer.size() == 1 && answer[0] == CTRL_KEY('d')) break;
             std::cout << "Submitted text: " << answer << std::endl;
         }

--- a/test-standalone/CMakeLists.txt
+++ b/test-standalone/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(test-standalone CXX)
 
 if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11
+    set(CMAKE_CXX_STANDARD 17
         CACHE STRING "C++ standard" FORCE)
 endif ()
 


### PR DESCRIPTION
Manual merge of current cpp-terminal on LFortran and the main repo version. I confirmed this compiles in LFortran and things generally seem to work but the REPL test fails (runtime_error: tcgetattr() failed is thrown). Perhaps some testing of the examples here will reveal the problem.