### PR TITLE
split top level cmake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,11 +6,11 @@ project(cpp-terminal
         HOMEPAGE_URL "https://github.com/jupyter-xeus/cpp-terminal"
         LANGUAGES CXX)
 
+# set the C++ standard, if not set by the top level project
 if (NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 17
         CACHE STRING "C++ standard" FORCE)
 endif ()
-configure_file(cpp-terminal/version.h.in cpp-terminal/version.h)
 
 option(CPPTERMINAL_BUILD_EXAMPLES "Set to ON to build examples" ON)
 option(CPPTERMINAL_ENABLE_INSTALL "Set to ON to enable install" ON)
@@ -18,13 +18,7 @@ option(CPPTERMINAL_ENABLE_TESING "Set to ON to enable testing" ON)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-add_library(cpp-terminal cpp-terminal/terminal_base.cpp)
-target_include_directories(cpp-terminal BEFORE PUBLIC
-    ${cpp-terminal_SOURCE_DIR})
-target_include_directories(cpp-terminal INTERFACE ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
-set_target_properties(cpp-terminal PROPERTIES
-    PUBLIC_HEADER "cpp-terminal/terminal.h;cpp-terminal/terminal_base.h;cpp-terminal/version.h"
-)
+add_subdirectory(cpp-terminal)
 
 if (CPPTERMINAL_ENABLE_TESING)
     enable_testing()
@@ -36,40 +30,7 @@ if (CPPTERMINAL_BUILD_EXAMPLES)
 endif()
 
 if (CPPTERMINAL_ENABLE_INSTALL)
-    install(TARGETS cpp-terminal EXPORT cpp-terminalTargets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION include/cpp-terminal
-    )
-
-    include(CMakePackageConfigHelpers)
-
-    write_basic_package_version_file(
-      "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalConfigVersion.cmake"
-      VERSION ${CPPTERMINAL_VERSION}
-      COMPATIBILITY AnyNewerVersion
-    )
-
-    export(EXPORT cpp-terminalTargets
-      FILE "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalTargets.cmake"
-    )
-    
-    set(ConfigPackageLocation lib/cmake/cpp-terminal)
-
-    configure_file(cpp-terminalConfig.cmake.in
-      "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalConfig.cmake"
-    )
-
-    install(
-      FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalConfig.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalConfigVersion.cmake"
-        "${CMAKE_CURRENT_BINARY_DIR}/cpp-terminal/cpp-terminalTargets.cmake"
-      DESTINATION
-        ${ConfigPackageLocation}
-      COMPONENT
-        Devel
-    )
+  include(cmake/install.cmake)
+  install_library(cpp-terminal)
 
 endif()

--- a/cmake/install.cmake
+++ b/cmake/install.cmake
@@ -1,0 +1,32 @@
+function(install_library TARGET_LIB_NAME)
+
+install(TARGETS ${TARGET_LIB_NAME} EXPORT ${TARGET_LIB_NAME}Targets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+    PUBLIC_HEADER DESTINATION include/${TARGET_LIB_NAME}
+)
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}ConfigVersion.cmake"
+    VERSION ${CPPTERMINAL_VERSION}
+    COMPATIBILITY AnyNewerVersion
+)
+export(EXPORT ${TARGET_LIB_NAME}Targets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}Targets.cmake"
+)
+set(ConfigPackageLocation lib/cmake/${TARGET_LIB_NAME})
+configure_file(${TARGET_LIB_NAME}Config.cmake.in
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}Config.cmake"
+)
+install(
+    FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}ConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_LIB_NAME}/${TARGET_LIB_NAME}Targets.cmake"
+    DESTINATION
+    ${ConfigPackageLocation}
+    COMPONENT
+    Devel
+)    
+endfunction(install_library TARGET_LIB_NAME)

--- a/cpp-terminal/CMakeLists.txt
+++ b/cpp-terminal/CMakeLists.txt
@@ -1,0 +1,15 @@
+# configure version information
+configure_file(version.h.in version.h)
+
+# create and confirgure library target
+add_library(cpp-terminal terminal_base.cpp)
+
+target_include_directories(cpp-terminal BEFORE PUBLIC
+    ${cpp-terminal_SOURCE_DIR}
+)
+
+target_include_directories(cpp-terminal INTERFACE ${PROJECT_SOURCE_DIR} ${PROJECT_BINARY_DIR})
+
+set_target_properties(cpp-terminal PROPERTIES
+    PUBLIC_HEADER "cpp-terminal/terminal.h;cpp-terminal/terminal_base.h;cpp-terminal/version.h"
+)


### PR DESCRIPTION
This PR simply splits the top level cmake file into a smaller one for the library itself and a install function for better cmake maintaining.