### PR TITLE
added github action to check if clang format was applied

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,26 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.3.0
+      with:
+        clang-format-version: '13'
+        check-path: 'cpp-terminal/'
+        fallback-style: 'Mozilla' # optional
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.3.0
+      with:
+        clang-format-version: '13'
+        check-path: 'examples/'
+        fallback-style: 'Mozilla' # optional
+    - name: Run clang-format style check for C/C++ programs.
+      uses: jidicula/clang-format-action@v4.3.0
+      with:
+        clang-format-version: '13'
+        check-path: 'tests/test-standalone/'
+        fallback-style: 'Mozilla' # optional


### PR DESCRIPTION
This PR adds a github action check that fails if clang-format wasn't applied. This will help to keep the code of the master branch clean.