### PR TITLE
Out of range error in prompt example for ENTER input

### DIFF
--- a/examples/prompt.cpp
+++ b/examples/prompt.cpp
@@ -12,7 +12,7 @@ using Term::Terminal;
 bool determine_completeness([[maybe_unused]] std::string command) {
     // Determine if the statement is complete
     bool complete;
-    if (command.substr(command.size() - 2, 1) == "\\") {
+    if (command.size() > 1 && command.substr(command.size() - 2, 1) == "\\") {
         complete = false;
     } else {
         complete = true;


### PR DESCRIPTION
Noticed this error when running the prompt example, just hitting enter will throw an out of range exception:

```
terminate called after throwing an instance of 'std::out_of_range'                                                                                                                   1,1   ]
  what():  basic_string::substr: __pos (which is 18446744073709551615) > this->size() (which is 1)

gdb:
  0x00005555555575da in determine_completeness (command="\n") at /home/awvwgk/projects/src/git/cpp-terminal/examples/prompt.cpp:15
```