### PR TITLE
Ported some fixes 

### DIFF
--- a/cpp-terminal/base.cpp
+++ b/cpp-terminal/base.cpp
@@ -122,14 +122,18 @@ void Term::get_cursor_position(int& rows, int& cols) {
 
 Term::Terminal::Terminal(bool _clear_screen,
                          bool enable_keyboard,
-                         bool disable_ctrl_c)
+                         bool disable_ctrl_c,
+                         bool _hide_cursor)
     : BaseTerminal(enable_keyboard, disable_ctrl_c),
-      clear_screen{_clear_screen} {
+      clear_screen{_clear_screen},
+      hide_cursor{_hide_cursor} {
     if (clear_screen) {
         write(save_screen() +
               // fixes consoles that ignore save_screen()
               clear_screen_buffer());
     }
+    if (hide_cursor)
+        write(cursor_off());
 }
 Term::Terminal::Terminal(bool _clear_screen)
     : BaseTerminal(false, true), clear_screen{_clear_screen} {
@@ -147,4 +151,6 @@ Term::Terminal::~Terminal() {
               // restores the screen, might be ignored by some terminals
               restore_screen());
     }
+    if (hide_cursor)
+        write(cursor_on());
 }

--- a/cpp-terminal/base.cpp
+++ b/cpp-terminal/base.cpp
@@ -130,15 +130,27 @@ Term::Terminal::Terminal(bool _clear_screen,
                          bool disable_ctrl_c)
     : BaseTerminal(enable_keyboard, disable_ctrl_c),
       clear_screen{_clear_screen} {
-    if (clear_screen)
+    if (clear_screen) {
         save_screen();
+        // fixes consoles that ignore save_screen()
+        write(clear_screen_buffer());
+    }
 }
 Term::Terminal::Terminal(bool _clear_screen)
     : BaseTerminal(false, true), clear_screen{_clear_screen} {
-    if (clear_screen)
+    if (clear_screen) {
         save_screen();
+        // fixes consoles that ignore save_screen()
+        write(clear_screen_buffer());
+    }
 }
 Term::Terminal::~Terminal() {
-    if (clear_screen)
+    if (clear_screen) {
+        // fixes consoles that ignore save_screen()
+        write(color(Term::style::reset) + clear_screen_buffer() +
+              move_cursor(1, 1));
+
+        // restores the screen, might be ignored by some terminals
         restore_screen();
+    }
 }

--- a/cpp-terminal/base.cpp
+++ b/cpp-terminal/base.cpp
@@ -77,19 +77,14 @@ bool Term::get_term_size(int& rows, int& cols) {
     return Private::get_term_size(rows, cols);
 }
 
-void Term::restore_screen() {
-    write("\033[?1049l");  // restore screen
-    write(
-        "\033"
-        "8");  // restore current cursor position
-    // restore_screen_ = false;
+std::string Term::restore_screen() {
+    return "\033[?1049l"  // restores screen
+           "\0338";       // restore current cursor position
 }
 
-void Term::save_screen() {
-    write(
-        "\033"
-        "7");              // save current cursor position
-    write("\033[?1049h");  // save screen
+std::string Term::save_screen() {
+    return "\0337"         // save current cursor position
+           "\033[?1049h";  // save screen
 }
 
 void Term::get_cursor_position(int& rows, int& cols) {
@@ -131,26 +126,25 @@ Term::Terminal::Terminal(bool _clear_screen,
     : BaseTerminal(enable_keyboard, disable_ctrl_c),
       clear_screen{_clear_screen} {
     if (clear_screen) {
-        save_screen();
-        // fixes consoles that ignore save_screen()
-        write(clear_screen_buffer());
+        write(save_screen() +
+              // fixes consoles that ignore save_screen()
+              clear_screen_buffer());
     }
 }
 Term::Terminal::Terminal(bool _clear_screen)
     : BaseTerminal(false, true), clear_screen{_clear_screen} {
     if (clear_screen) {
-        save_screen();
-        // fixes consoles that ignore save_screen()
-        write(clear_screen_buffer());
+        write(save_screen()
+              // fixes consoles that ignore save_screen()
+              + clear_screen_buffer());
     }
 }
 Term::Terminal::~Terminal() {
     if (clear_screen) {
         // fixes consoles that ignore save_screen()
         write(color(Term::style::reset) + clear_screen_buffer() +
-              move_cursor(1, 1));
-
-        // restores the screen, might be ignored by some terminals
-        restore_screen();
+              move_cursor(1, 1) +
+              // restores the screen, might be ignored by some terminals
+              restore_screen());
     }
 }

--- a/cpp-terminal/base.hpp
+++ b/cpp-terminal/base.hpp
@@ -99,9 +99,9 @@ bool is_stdin_a_tty();
 bool is_stdout_a_tty();
 bool get_term_size(int&, int&);
 
-void restore_screen();
+std::string restore_screen();
 
-void save_screen();
+std::string save_screen();
 
 void get_cursor_position(int&, int&);
 

--- a/cpp-terminal/base.hpp
+++ b/cpp-terminal/base.hpp
@@ -109,9 +109,13 @@ void get_cursor_position(int&, int&);
 class Terminal : public Private::BaseTerminal {
    private:
     bool clear_screen{};
+    bool hide_cursor{};
 
    public:
-    Terminal(bool _clear_screen, bool enable_keyboard, bool disable_ctrl_c);
+    Terminal(bool _clear_screen,
+             bool enable_keyboard,
+             bool disable_ctrl_c,
+             bool);
     // providing no parameters will disable the keyboard and ctrl+c
     Terminal(bool _clear_screen);
 

--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -10,7 +10,7 @@ Term::Result Term::prompt(const std::string& message,
                           const std::string& second_option,
                           const std::string& prompt_indicator,
                           bool immediate) {
-    Terminal term(false, true, true);
+    Terminal term(false, true, true, false);
     std::cout << message << " [" << first_option << '/' << second_option << ']'
               << prompt_indicator << ' ' << std::flush;
 

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -10,7 +10,7 @@ using Term::Terminal;
 
 int main() {
     try {
-        Terminal term(true, true, false);
+        Terminal term(true, true, false, false);
         int rows{}, cols{};
         Term::get_term_size(rows, cols);
         std::cout << "Dimension:" << cols << " " << rows << std::endl;

--- a/examples/kilo.cpp
+++ b/examples/kilo.cpp
@@ -929,7 +929,7 @@ int main(int argc, char* argv[]) {
     // being called when exception happens and the terminal is not put into
     // correct state.
     try {
-        Terminal term(true, true, false);
+        Terminal term(true, true, false, false);
         initEditor();
         if (argc >= 2) {
             editorOpen(argv[1]);

--- a/examples/menu.cpp
+++ b/examples/menu.cpp
@@ -16,7 +16,6 @@ void render(int rows, int cols, int menuheight, int menuwidth, int menupos) {
     std::string scr;
     scr.reserve(16 * 1024);
 
-    scr.append(cursor_off());
     scr.append(move_cursor(1, 1));
 
     int menux0 = (cols - menuwidth) / 2;
@@ -74,14 +73,12 @@ void render(int rows, int cols, int menuheight, int menuwidth, int menupos) {
     scr.append("Menu width: " + std::to_string(menuwidth) + "       \n");
     scr.append("Menu height: " + std::to_string(menuheight) + "    \n");
 
-    scr.append(cursor_on());
-
     std::cout << scr << std::flush;
 }
 
 int main() {
     try {
-        Terminal term(true, true, false);
+        Terminal term(true, true, false, true);
         int rows{}, cols{};
         Term::get_term_size(rows, cols);
         int pos = 5;

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -50,7 +50,7 @@ std::string render(Term::Window& scr,
 
 int main() {
     try {
-        Terminal term(true, true, false);
+        Terminal term(true, true, false, false);
         int rows{}, cols{};
         Term::get_term_size(rows, cols);
         int pos = 5;

--- a/examples/menu_window_24bit.cpp
+++ b/examples/menu_window_24bit.cpp
@@ -50,7 +50,7 @@ std::string render(Term::Window_24bit& scr,
 
 int main() {
     try {
-        Terminal term(true, true, false);
+        Terminal term(true, true, false, false);
         int rows{}, cols{};
         Term::get_term_size(rows, cols);
         int pos = 5;

--- a/examples/prompt_multiline.cpp
+++ b/examples/prompt_multiline.cpp
@@ -22,7 +22,7 @@ bool determine_completeness([[maybe_unused]] std::string command) {
 
 int main() {
     try {
-        Terminal term(false, true, false);
+        Terminal term(false, true, false, false);
         std::cout << "Interactive prompt." << std::endl;
         std::cout << "  * Use Ctrl-D to exit." << std::endl;
         std::cout << "  * Use Enter to submit." << std::endl;


### PR DESCRIPTION
This PR fixes the screen clearing if the given terminal is not supporting the `save_screen()` function (The linux VGA/TTY console for example). I have also added an option to automatically hide the cursor.