### PR TITLE
removed get_term_size_slow()

### DIFF
--- a/cpp-terminal/base.cpp
+++ b/cpp-terminal/base.cpp
@@ -124,22 +124,6 @@ void Term::get_cursor_position(int& rows, int& cols) {
     throw std::runtime_error(
         "get_cursor_position(): result not found in the response");
 }
-// TODO: repair or remove
-// void Term::get_term_size_slow(int& rows, int& cols) {
-//     struct CursorOff {
-//         const Terminal& term;
-//         explicit CursorOff(const Terminal& term) : term{term} {
-//             write(cursor_off());
-//         }
-//         ~CursorOff() { write(cursor_on()); }
-//     };
-//     CursorOff cursor_off(*this);
-//     int old_row{}, old_col{};
-//     get_cursor_position(old_row, old_col);
-//     write(move_cursor_right(999) + move_cursor_down(999));
-//     get_cursor_position(rows, cols);
-//     write(move_cursor(old_row, old_col));
-// }
 
 Term::Terminal::Terminal(bool _clear_screen,
                          bool enable_keyboard,

--- a/cpp-terminal/base.hpp
+++ b/cpp-terminal/base.hpp
@@ -105,9 +105,6 @@ void save_screen();
 
 void get_cursor_position(int&, int&);
 
-// This function takes about 23ms, so it should only be used as a fallback
-void get_term_size_slow(int&, int&);
-
 // initializes the terminal
 class Terminal : public Private::BaseTerminal {
    private:


### PR DESCRIPTION
This PR removes the `get_term_size_slow()` function. I tried to fix it because it wouldn't compile after the header changes, but it seems like the function is generally not working. I tried a very old commit, but there this function was already broken. Could be an issue with my terminal though, but Kitty and the vscode terminal both just show some characters and even after minutes nothing happens. If you want to keep the function nevertheless, you need to help on this one @certik.

Fixes #115.