### PR TITLE
Automatically choose the right palette 

### DIFF
--- a/cpp-terminal/platforms/terminfo.cpp
+++ b/cpp-terminal/platforms/terminfo.cpp
@@ -26,21 +26,25 @@ bool WindowsVersionGreater(const DWORD& major, const DWORD& minor, const DWORD& 
 }
 #endif
 
+#include <iostream>
+#include <utility>
+
 namespace Private
 {
-std::string getenv(const std::string& env)
+std::pair<bool, std::string> getenv(const std::string& env)
 {
 #ifdef _WIN32
   std::size_t requiredSize{0};
   getenv_s(&requiredSize, nullptr, 0, env.c_str());
-  if(requiredSize == 0) return std::string();
+  if(requiredSize == 0) return {false, std::string()};
   std::string ret;
   ret.reserve(requiredSize * sizeof(char));
   getenv_s(&requiredSize, &ret[0], requiredSize, env.c_str());
+  return {true, ret};
 #else
-  if(std::getenv(env.c_str()) != nullptr) return static_cast<std::string>(std::getenv(env.c_str()));
+  if(std::getenv(env.c_str()) != nullptr) return {true, static_cast<std::string>(std::getenv(env.c_str()))};
   else
-    return std::string();
+    return {false, std::string()};
 #endif
 }
 }  // namespace Private
@@ -49,6 +53,10 @@ Term::Terminfo::ColorMode Term::Terminfo::m_colorMode{Term::Terminfo::ColorMode:
 
 Term::Terminfo::Terminfo()
 {
+  m_term            = Private::getenv("TERM").second;
+  m_terminalName    = Private::getenv("TERM_PROGRAM").second;
+  m_terminalName    = Private::getenv("TERMINAL_EMULATOR").second;
+  m_terminalVersion = Private::getenv("TERM_PROGRAM_VERSION").second;
   setANSIEscapeCode();
   setColorMode();
 }
@@ -57,10 +65,15 @@ bool Term::Terminfo::hasANSIEscapeCode() { return m_ANSIEscapeCode; }
 
 void Term::Terminfo::setColorMode()
 {
-  std::string colorterm = Private::getenv("COLORTERM");
+  std::string colorterm = Private::getenv("COLORTERM").second;
   if(colorterm == "truecolor" || colorterm == "24bit") m_colorMode = Term::Terminfo::ColorMode::Bit24;
   else
     m_colorMode = Term::Terminfo::ColorMode::Bit8;
+  if(m_terminalName == "Apple_Terminal") m_colorMode = Term::Terminfo::ColorMode::Bit8;
+  else if(m_terminalName == "JetBrains-JediTerm")
+    m_colorMode = Term::Terminfo::ColorMode::Bit24;
+  else if(m_terminalName == "vscode")
+    m_colorMode = Term::Terminfo::ColorMode::Bit24;
 }
 
 void Term::Terminfo::setANSIEscapeCode()

--- a/cpp-terminal/platforms/terminfo.cpp
+++ b/cpp-terminal/platforms/terminfo.cpp
@@ -53,9 +53,10 @@ Term::Terminfo::ColorMode Term::Terminfo::m_colorMode{Term::Terminfo::ColorMode:
 
 Term::Terminfo::Terminfo()
 {
-  m_term            = Private::getenv("TERM").second;
-  m_terminalName    = Private::getenv("TERM_PROGRAM").second;
-  m_terminalName    = Private::getenv("TERMINAL_EMULATOR").second;
+  m_term         = Private::getenv("TERM").second;
+  m_terminalName = Private::getenv("TERM_PROGRAM").second;
+  m_terminalName = Private::getenv("TERMINAL_EMULATOR").second;
+  if(Private::getenv("ANSICON").first) m_terminalName = "ansicon";
   m_terminalVersion = Private::getenv("TERM_PROGRAM_VERSION").second;
   setANSIEscapeCode();
   setColorMode();
@@ -74,6 +75,13 @@ void Term::Terminfo::setColorMode()
     m_colorMode = Term::Terminfo::ColorMode::Bit24;
   else if(m_terminalName == "vscode")
     m_colorMode = Term::Terminfo::ColorMode::Bit24;
+#ifdef _WIN32
+  if(WindowsVersionGreater(10, 0, 10586)) m_colorMode = Term::Terminfo::ColorMode::Bit24;
+  else if(m_terminalName == "ansicon")
+    m_colorMode = Term::Terminfo::ColorMode::Bit4;
+  else
+    m_colorMode = Term::Terminfo::ColorMode::Bit4;
+#endif
 }
 
 void Term::Terminfo::setANSIEscapeCode()

--- a/cpp-terminal/terminfo.hpp
+++ b/cpp-terminal/terminfo.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 namespace Term
 {
 
@@ -31,6 +33,9 @@ private:
   bool             m_ANSIEscapeCode{true};
   void             setColorMode();
   static ColorMode m_colorMode;
+  std::string      m_terminalName;
+  std::string      m_terminalVersion;
+  std::string      m_term;
 };
 
 }  // namespace Term


### PR DESCRIPTION
This is fixing #108 by checking if we use the MacOS terminal and convert all to 8bits colors.
ANSICON is detected too and convert all to 4bits (ANSICON do this by itself but we do it by ourself)

Still need to be fixed : old window$ without ANSICON

Windows with ANSICON on `Window$ 7` (It takes centuries to print but....) : 

![](https://user-images.githubusercontent.com/8627746/226208724-7babb058-5f52-41e2-bb8b-444a020cb45b.png)

MacOS terminal (I could not imagine MacOS still use 256colors):
![](https://user-images.githubusercontent.com/8627746/226209097-96cee290-8fe6-473f-8c0d-c02e59aec284.png)
 
For other terminal we need a terminfo parser and use TERM env variable to have better information but we check for COLORTERM value and fallback as 8bits colors by default 