### PR TITLE
Fixes and new features

### DIFF
--- a/cpp-terminal/CMakeLists.txt
+++ b/cpp-terminal/CMakeLists.txt
@@ -1,16 +1,16 @@
 # configure version information
-configure_file(version.hpp.in version.hpp)
+configure_file(version.cpp.in version.cpp)
 
 add_subdirectory(platforms)
 
 # create and configure library target
-add_library(cpp-terminal prompt.cpp window.cpp input.cpp terminal.cpp color.cpp key.cpp event.cpp screen.cpp options.cpp cursor.cpp style.cpp io.cpp)
+add_library(cpp-terminal prompt.cpp window.cpp input.cpp terminal.cpp color.cpp key.cpp event.cpp screen.cpp options.cpp cursor.cpp style.cpp io.cpp "${CMAKE_CURRENT_BINARY_DIR}/version.cpp")
 target_link_libraries(cpp-terminal PRIVATE Warnings::Warnings cpp-terminal::cpp-terminal-platforms)
 target_compile_options(cpp-terminal PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 target_include_directories(cpp-terminal PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
 
 set_target_properties(cpp-terminal PROPERTIES
-                      PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/options.hpp;${CMAKE_CURRENT_SOURCE_DIR}/event.hpp;${CMAKE_CURRENT_SOURCE_DIR}/key.hpp;${CMAKE_CURRENT_SOURCE_DIR}/tty.hpp;${CMAKE_CURRENT_SOURCE_DIR}/terminal.hpp;${CMAKE_CURRENT_SOURCE_DIR}/cursor.hpp;${CMAKE_CURRENT_SOURCE_DIR}/style.hpp;${CMAKE_CURRENT_SOURCE_DIR}/prompt.hpp;${CMAKE_CURRENT_SOURCE_DIR}/window.hpp;${CMAKE_CURRENT_BINARY_DIR}/version.hpp"
+                      PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/options.hpp;${CMAKE_CURRENT_SOURCE_DIR}/event.hpp;${CMAKE_CURRENT_SOURCE_DIR}/key.hpp;${CMAKE_CURRENT_SOURCE_DIR}/tty.hpp;${CMAKE_CURRENT_SOURCE_DIR}/terminal.hpp;${CMAKE_CURRENT_SOURCE_DIR}/cursor.hpp;${CMAKE_CURRENT_SOURCE_DIR}/style.hpp;${CMAKE_CURRENT_SOURCE_DIR}/prompt.hpp;${CMAKE_CURRENT_SOURCE_DIR}/window.hpp;${CMAKE_CURRENT_SOURCE_DIR}/version.hpp"
                       PRIVATE_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/platforms/conversion.hpp;${CMAKE_CURRENT_SOURCE_DIR}/platforms/macros.hpp")
 
 add_library(cpp-terminal::cpp-terminal ALIAS cpp-terminal)

--- a/cpp-terminal/CMakeLists.txt
+++ b/cpp-terminal/CMakeLists.txt
@@ -4,7 +4,7 @@ configure_file(version.hpp.in version.hpp)
 add_subdirectory(platforms)
 
 # create and configure library target
-add_library(cpp-terminal prompt.cpp window.cpp input.cpp terminal.cpp color.cpp key.cpp event.cpp screen.cpp options.cpp cursor.cpp style.cpp)
+add_library(cpp-terminal prompt.cpp window.cpp input.cpp terminal.cpp color.cpp key.cpp event.cpp screen.cpp options.cpp cursor.cpp style.cpp io.cpp)
 target_link_libraries(cpp-terminal PRIVATE Warnings::Warnings cpp-terminal::cpp-terminal-platforms)
 target_compile_options(cpp-terminal PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
 target_include_directories(cpp-terminal PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)

--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -6,7 +6,7 @@ std::size_t Term::Cursor::row() const { return m_position.first; }
 
 std::size_t Term::Cursor::column() const { return m_position.second; }
 
-bool Term::Cursor::empty()
+bool Term::Cursor::empty() const
 {
   if(m_position.first == 0 && m_position.second == 0) return true;
   else

--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -1,9 +1,5 @@
 #include "cpp-terminal/cursor.hpp"
 
-#include "cpp-terminal/input.hpp"
-
-#include <iostream>
-
 Term::Cursor::Cursor(const std::size_t& row, const std::size_t& column) : m_position({row, column}) {}
 
 std::size_t Term::Cursor::row() const { return m_position.first; }

--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -21,16 +21,16 @@ std::string Term::cursor_off() { return "\x1b[?25l"; }
 
 std::string Term::cursor_on() { return "\x1b[?25h"; }
 
-std::string Term::cursor_move(std::size_t row, std::size_t column) { return "\033[" + std::to_string(row) + ';' + std::to_string(column) + 'H'; }
+std::string Term::cursor_move(std::size_t row, std::size_t column) { return "\x1b[" + std::to_string(row) + ';' + std::to_string(column) + 'H'; }
 
-std::string Term::cursor_up(std::size_t rows) { return "\033[" + std::to_string(rows) + 'A'; }
+std::string Term::cursor_up(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'A'; }
 
-std::string Term::cursor_down(std::size_t rows) { return "\033[" + std::to_string(rows) + 'B'; }
+std::string Term::cursor_down(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'B'; }
 
-std::string Term::cursor_right(std::size_t columns) { return "\033[" + std::to_string(columns) + 'C'; }
+std::string Term::cursor_right(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'C'; }
 
-std::string Term::cursor_left(std::size_t columns) { return "\033[" + std::to_string(columns) + 'D'; }
+std::string Term::cursor_left(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'D'; }
 
-std::string Term::cursor_position_report() { return "\033[6n"; }
+std::string Term::cursor_position_report() { return "\x1b[6n"; }
 
-std::string Term::clear_eol() { return "\033[K"; }
+std::string Term::clear_eol() { return "\x1b[K"; }

--- a/cpp-terminal/cursor.hpp
+++ b/cpp-terminal/cursor.hpp
@@ -16,7 +16,7 @@ public:
   std::size_t column() const;
   void        setRow(const std::size_t&);
   void        setColum(const std::size_t&);
-  bool        empty();
+  bool        empty() const;
 
 private:
   std::pair<std::size_t, std::size_t> m_position{0, 0};

--- a/cpp-terminal/event.cpp
+++ b/cpp-terminal/event.cpp
@@ -1,9 +1,5 @@
 #include "cpp-terminal/event.hpp"
 
-#include "cpp-terminal/cursor.hpp"
-
-#include <iostream>
-
 bool Term::Event::empty()
 {
   if(m_Type == Type::Empty) return true;

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -2,8 +2,6 @@
 
 #include "cpp-terminal/terminal.hpp"
 
-#include <fstream>
-#include <iostream>
 #include <new>
 
 namespace Term
@@ -15,67 +13,16 @@ private:
 };
 static Container<Term::Terminal> termbuf;
 Terminal&                        terminal = reinterpret_cast<Term::Terminal&>(termbuf);
-static Container<std::ifstream>  cinbuf;
-std::ifstream&                   cin = reinterpret_cast<std::ifstream&>(cinbuf);
-static Container<std::ofstream>  coutbuf;
-std::ofstream&                   cout = reinterpret_cast<std::ofstream&>(coutbuf);
-static Container<std::ofstream>  cerrbuf;
-std::ofstream&                   cerr = reinterpret_cast<std::ofstream&>(cerrbuf);
-static Container<std::ofstream>  clogbuf;
-std::ofstream&                   clog = reinterpret_cast<std::ofstream&>(clogbuf);
 }  // namespace Term
 
 int Term::TerminalInitializer::m_counter{0};
 
 Term::TerminalInitializer::TerminalInitializer()
 {
-  if(m_counter++ == 0)
-  {
-    new(&Term::cout) std::ofstream();
-    new(&Term::cerr) std::ofstream();
-    new(&Term::clog) std::ofstream();
-    new(&Term::cin) std::ifstream();
-#if defined(_WIN32)
-    Term::cout.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-    Term::cerr.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
-    Term::clog.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
-    Term::cin.open("CONIN$", std::ofstream::in | std::ofstream::trunc);
-#else
-    Term::cout.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-    Term::cerr.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
-    Term::clog.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
-    Term::cin.open("/dev/tty", std::ofstream::in | std::ofstream::trunc);
-#endif
-    Term::cerr.clear();
-    Term::cin.clear();
-    new(&Term::terminal) Terminal();
-  }
+  if(m_counter++ == 0) new(&Term::terminal) Terminal();
 }
 
 Term::TerminalInitializer::~TerminalInitializer()
 {
-  if(--m_counter == 0)
-  {
-    if(Term::cout.is_open())
-    {
-      Term::cout.flush();
-      Term::cout.close();
-    }
-    if(Term::cerr.is_open())
-    {
-      Term::cerr.flush();
-      Term::cerr.close();
-    }
-    if(Term::clog.is_open())
-    {
-      Term::clog.flush();
-      Term::clog.close();
-    }
-    if(Term::cin.is_open()) { Term::cin.close(); }
-    (&Term::terminal)->~Terminal();
-  }
+  if(--m_counter == 0) { (&Term::terminal)->~Terminal(); }
 }

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -1,6 +1,9 @@
 #include "cpp-terminal/io.hpp"
+
 #include "cpp-terminal/terminal.hpp"
 
+#include <fstream>
+#include <iostream>
 #include <new>
 
 namespace Term
@@ -11,18 +14,68 @@ private:
   alignas(T) std::byte t_buff[sizeof(T)];
 };
 static Container<Term::Terminal> termbuf;
-Terminal&                  terminal = reinterpret_cast<Term::Terminal&>(termbuf);
-
-int TerminalInitializer::m_counter{0};
-
-TerminalInitializer::TerminalInitializer()
-{
-  if(m_counter++ == 0) new(&Term::terminal) Terminal();
-}
-
-TerminalInitializer::~TerminalInitializer()
-{
-  if(--m_counter == 0) (&Term::terminal)->~Terminal();
-}
-
+Terminal&                        terminal = reinterpret_cast<Term::Terminal&>(termbuf);
+static Container<std::ifstream>  cinbuf;
+std::ifstream&                   cin = reinterpret_cast<std::ifstream&>(cinbuf);
+static Container<std::ofstream>  coutbuf;
+std::ofstream&                   cout = reinterpret_cast<std::ofstream&>(coutbuf);
+static Container<std::ofstream>  cerrbuf;
+std::ofstream&                   cerr = reinterpret_cast<std::ofstream&>(cerrbuf);
+static Container<std::ofstream>  clogbuf;
+std::ofstream&                   clog = reinterpret_cast<std::ofstream&>(clogbuf);
 }  // namespace Term
+
+int Term::TerminalInitializer::m_counter{0};
+
+Term::TerminalInitializer::TerminalInitializer()
+{
+  if(m_counter++ == 0)
+  {
+    new(&Term::cout) std::ofstream();
+    new(&Term::cerr) std::ofstream();
+    new(&Term::clog) std::ofstream();
+    new(&Term::cin) std::ifstream();
+#if defined(_WIN32)
+    Term::cout.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
+    Term::cerr.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
+    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
+    Term::clog.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
+    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
+    Term::cin.open("CONIN$", std::ofstream::in | std::ofstream::trunc);
+#else
+    Term::cout.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
+    Term::cerr.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
+    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
+    Term::clog.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
+    Term::clog.rdbuf()->pubsetbuf(nullptr, 0);
+    Term::cin.open("/dev/tty", std::ofstream::in | std::ofstream::trunc);
+#endif
+    Term::cerr.clear();
+    Term::cin.clear();
+    new(&Term::terminal) Terminal();
+  }
+}
+
+Term::TerminalInitializer::~TerminalInitializer()
+{
+  if(--m_counter == 0)
+  {
+    if(Term::cout.is_open())
+    {
+      Term::cout.flush();
+      Term::cout.close();
+    }
+    if(Term::cerr.is_open())
+    {
+      Term::cerr.flush();
+      Term::cerr.close();
+    }
+    if(Term::clog.is_open())
+    {
+      Term::clog.flush();
+      Term::clog.close();
+    }
+    if(Term::cin.is_open()) { Term::cin.close(); }
+    (&Term::terminal)->~Terminal();
+  }
+}

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -6,13 +6,8 @@
 
 namespace Term
 {
-template<typename T> class Container
-{
-private:
-  alignas(alignof(T)) char buf[sizeof(T)];
-};
-static Container<Term::Terminal> termbuf;
-Terminal&                        terminal = reinterpret_cast<Term::Terminal&>(termbuf);
+static char termbuf[sizeof(Term::Terminal)];
+Terminal&   terminal = reinterpret_cast<Term::Terminal&>(termbuf);
 }  // namespace Term
 
 int Term::TerminalInitializer::m_counter{0};

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -1,0 +1,26 @@
+#include "cpp-terminal/terminal.hpp"
+
+#include <new>
+
+namespace Term
+{
+template<typename T> class Container
+{
+private:
+  alignas(T) std::byte t_buff[sizeof(T)];
+};
+static Container<Term::Terminal> termbuf;
+Term::Terminal&                  terminal = reinterpret_cast<Term::Terminal&>(termbuf);
+}  // namespace Term
+
+int Term::TerminalInitializer::m_counter{0};
+
+Term::TerminalInitializer::TerminalInitializer()
+{
+  if(m_counter++ == 0) new(&Term::terminal) Terminal();
+}
+
+Term::TerminalInitializer::~TerminalInitializer()
+{
+  if(--m_counter == 0) (&Term::terminal)->~Terminal();
+}

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -1,3 +1,4 @@
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/terminal.hpp"
 
 #include <new>
@@ -10,17 +11,18 @@ private:
   alignas(T) std::byte t_buff[sizeof(T)];
 };
 static Container<Term::Terminal> termbuf;
-Term::Terminal&                  terminal = reinterpret_cast<Term::Terminal&>(termbuf);
-}  // namespace Term
+Terminal&                  terminal = reinterpret_cast<Term::Terminal&>(termbuf);
 
-int Term::TerminalInitializer::m_counter{0};
+int TerminalInitializer::m_counter{0};
 
-Term::TerminalInitializer::TerminalInitializer()
+TerminalInitializer::TerminalInitializer()
 {
   if(m_counter++ == 0) new(&Term::terminal) Terminal();
 }
 
-Term::TerminalInitializer::~TerminalInitializer()
+TerminalInitializer::~TerminalInitializer()
 {
   if(--m_counter == 0) (&Term::terminal)->~Terminal();
 }
+
+}  // namespace Term

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -9,7 +9,7 @@ namespace Term
 template<typename T> class Container
 {
 private:
-  alignas(T) std::byte t_buff[sizeof(T)];
+  alignas(T) char t_buff[sizeof(T)];
 };
 static Container<Term::Terminal> termbuf;
 Terminal&                        terminal = reinterpret_cast<Term::Terminal&>(termbuf);

--- a/cpp-terminal/io.cpp
+++ b/cpp-terminal/io.cpp
@@ -9,7 +9,7 @@ namespace Term
 template<typename T> class Container
 {
 private:
-  alignas(T) char t_buff[sizeof(T)];
+  alignas(alignof(T)) char buf[sizeof(T)];
 };
 static Container<Term::Terminal> termbuf;
 Terminal&                        terminal = reinterpret_cast<Term::Terminal&>(termbuf);

--- a/cpp-terminal/io.hpp
+++ b/cpp-terminal/io.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+namespace Term
+{
+
+class Terminal;
+extern Terminal& terminal;
+
+class TerminalInitializer
+{
+public:
+  TerminalInitializer();
+  ~TerminalInitializer();
+
+private:
+  static int m_counter;
+};
+
+static TerminalInitializer m_terminalInitializer;
+
+}  // namespace Term

--- a/cpp-terminal/io.hpp
+++ b/cpp-terminal/io.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iosfwd>
-
 namespace Term
 {
 
@@ -19,10 +17,5 @@ private:
 };
 
 static TerminalInitializer m_terminalInitializer;
-
-extern std::ofstream& cout;
-extern std::ofstream& cerr;
-extern std::ofstream& clog;
-extern std::ifstream& cin;
 
 }  // namespace Term

--- a/cpp-terminal/io.hpp
+++ b/cpp-terminal/io.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <iosfwd>
+
 namespace Term
 {
 
@@ -18,6 +20,9 @@ private:
 
 static TerminalInitializer m_terminalInitializer;
 
-
+extern std::ofstream& cout;
+extern std::ofstream& cerr;
+extern std::ofstream& clog;
+extern std::ifstream& cin;
 
 }  // namespace Term

--- a/cpp-terminal/io.hpp
+++ b/cpp-terminal/io.hpp
@@ -18,4 +18,6 @@ private:
 
 static TerminalInitializer m_terminalInitializer;
 
+
+
 }  // namespace Term

--- a/cpp-terminal/options.cpp
+++ b/cpp-terminal/options.cpp
@@ -1,6 +1,7 @@
 #include "cpp-terminal/options.hpp"
 
 #include <algorithm>
+
 Term::Options::Options(const std::vector<Option>& options) : m_Options(options) {}
 
 std::vector<Term::Options::Option> Term::Options::getOptions() { return m_Options; }

--- a/cpp-terminal/options.cpp
+++ b/cpp-terminal/options.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 Term::Options::Options(const std::vector<Option>& options) : m_Options(options) {}
 
+std::vector<Term::Options::Option> Term::Options::getOptions() { return m_Options; }
+
 // Return true is the option is set and not its opposite (* + No* = false)
 bool Term::Options::has(const Option& option)
 {

--- a/cpp-terminal/options.hpp
+++ b/cpp-terminal/options.hpp
@@ -23,7 +23,7 @@ public:
     NoCursor      = -4,
   };
   Options() = default;
-  Options(const std::vector<Option>& options);
+  explicit Options(const std::vector<Option>& options);
   bool has(const Option& option);
   ~Options() {}
   std::vector<Option> getOptions();

--- a/cpp-terminal/options.hpp
+++ b/cpp-terminal/options.hpp
@@ -12,13 +12,17 @@ public:
   enum class Option : int
   {
     // Don't use 0!
-    ClearScreen   = 1,
-    NoClearScreen = -1,
-    SignalKeys    = 2,
-    NoSignalKeys  = -2,
-    Cursor        = 3,
-    NoCursor      = -3,
+    Default       = 0,
+    Raw           = 1,
+    Cooked        = -1,
+    ClearScreen   = 2,
+    NoClearScreen = -2,
+    SignalKeys    = 3,
+    NoSignalKeys  = -3,
+    Cursor        = 4,
+    NoCursor      = -4,
   };
+  Options() = default;
   Options(const std::vector<Option>& options);
   bool has(const Option& option);
   ~Options() {}

--- a/cpp-terminal/options.hpp
+++ b/cpp-terminal/options.hpp
@@ -26,6 +26,7 @@ public:
   Options(const std::vector<Option>& options);
   bool has(const Option& option);
   ~Options() {}
+  std::vector<Option> getOptions();
 
 private:
   std::vector<Option> m_Options;

--- a/cpp-terminal/platforms/CMakeLists.txt
+++ b/cpp-terminal/platforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(cpp-terminal-platforms terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp)
 target_link_libraries(cpp-terminal-platforms PRIVATE Warnings::Warnings)
-target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8>)
+target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8 /wd4668>)
 target_include_directories(cpp-terminal-platforms PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
 add_library(cpp-terminal::cpp-terminal-platforms ALIAS cpp-terminal-platforms)

--- a/cpp-terminal/platforms/CMakeLists.txt
+++ b/cpp-terminal/platforms/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_library(cpp-terminal-platforms terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp)
 target_link_libraries(cpp-terminal-platforms PRIVATE Warnings::Warnings)
-target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8 /wd4668>)
+target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8 /wd4668 /wd4514>)
 target_include_directories(cpp-terminal-platforms PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)
 add_library(cpp-terminal::cpp-terminal-platforms ALIAS cpp-terminal-platforms)

--- a/cpp-terminal/platforms/cursor.cpp
+++ b/cpp-terminal/platforms/cursor.cpp
@@ -3,10 +3,8 @@
 #if defined(_WIN32)
   #include "windows.h"
 #else
-  #include "cpp-terminal/event.hpp"
   #include "cpp-terminal/input.hpp"
-
-  #include <iostream>
+  #include "cpp-terminal/terminal.hpp"
 #endif
 
 Term::Cursor Term::cursor_position()
@@ -19,10 +17,9 @@ Term::Cursor Term::cursor_position()
   CloseHandle(hConOut);
   return ret;
 #else
-  std::cout << Term::cursor_position_report() << std::flush;
-  Term::Event c;
-  while((c = Platform::read_raw()).empty())
-    ;
+  Term::terminal << Term::cursor_position_report();
+  Term::Cursor c;
+  while((c = Platform::read_raw()).empty()) continue;
   return c;
 #endif
 }

--- a/cpp-terminal/platforms/screen.cpp
+++ b/cpp-terminal/platforms/screen.cpp
@@ -21,11 +21,8 @@ Term::Screen Term::screen_size()
   Term::Screen   ret;
   struct winsize window
   {
+    0, 0, 0, 0
   };
-  window.ws_row    = 0;
-  window.ws_col    = 0;
-  window.ws_xpixel = 0;
-  window.ws_ypixel = 0;
   int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
   if(ioctl(fd, TIOCGWINSZ, &window) != -1) ret = {window.ws_row, window.ws_col};
   close(fd);

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -75,7 +75,11 @@ void Term::Terminal::store_and_restore()
     enabled = false;
   }
 #else
+  #if defined(__mips__) || defined(__mips) || defined(__MIPS__)
+  static termios orig_termios{0, 0, 0, 0, 0, {}};
+  #else
   static termios orig_termios{0, 0, 0, 0, 0, {}, 0, 0};
+  #endif
   if(!enabled)
   {
     int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
@@ -113,7 +117,11 @@ void Term::Terminal::setRawMode()
   int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
   if(fd >= 0)
   {
-    termios raw{0, 0, 0, 0, 0, {0}, 0, 0};
+  #if defined(__mips__) || defined(__mips) || defined(__MIPS__)
+    static termios raw{0, 0, 0, 0, 0, {}};
+  #else
+    static termios raw{0, 0, 0, 0, 0, {}, 0, 0};
+  #endif
     if(tcgetattr(fd, &raw) == -1) { throw Term::Exception("tcgetattr() failed"); }
     // Put terminal in raw mode
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -75,7 +75,7 @@ void Term::Terminal::store_and_restore()
     enabled = false;
   }
 #else
-  static termios orig_termios{0, 0, 0, 0, 0, {0}, 0, 0};
+  static termios orig_termios{0, 0, 0, 0, 0, {}, 0, 0};
   if(!enabled)
   {
     int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -1,5 +1,4 @@
 #include "cpp-terminal/terminal.hpp"
-#include "cpp-terminal/io.hpp"
 
 #ifdef _WIN32
   #include <io.h>
@@ -21,8 +20,6 @@
 #endif
 
 #include "cpp-terminal/exception.hpp"
-
-#include <iostream>
 
 void Term::Terminal::store_and_restore()
 {
@@ -152,52 +149,11 @@ void Term::Terminal::attachConsole()
     if(_fileno(stderr) < 0 || _get_osfhandle(_fileno(stderr)) < 0) freopen_s(&dump, "CONOUT$", "w", stderr);
     if(_fileno(stdin) < 0 || _get_osfhandle(_fileno(stdin)) < 0) freopen_s(&dump, "CONIN$", "r", stdin);
   }
-  m_stdout.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-  m_stderr.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-  m_stdlog.rdbuf()->pubsetbuf(nullptr,0);
-  m_stdlog.open("CONOUT$", std::ofstream::out | std::ofstream::trunc);
-  m_stdlog.rdbuf()->pubsetbuf(nullptr,0);
-  m_stdin.open("CONIN$", std::ofstream::in | std::ofstream::trunc);
-#else
-  m_stdout.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-  m_stderr.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-  m_stdlog.rdbuf()->pubsetbuf(nullptr,0);
-  m_stdlog.open("/dev/tty", std::ofstream::out | std::ofstream::trunc);
-  m_stdlog.rdbuf()->pubsetbuf(nullptr,0);
-  m_stdin.open("/dev/tty", std::ofstream::in | std::ofstream::trunc);
 #endif
-  std::ios_base::Init();
-  std::cout.clear();
-  std::clog.clear();
-  std::cerr.clear();
-  std::cin.clear();
-  std::wcout.clear();
-  std::wclog.clear();
-  std::wcerr.clear();
-  std::wcin.clear();
 }
 
 void Term::Terminal::detachConsole()
 {
-  if(m_stdout.is_open())
-  {
-    m_stdout.flush();
-    m_stdout.close();
-  }
-  if(m_stderr.is_open())
-  {
-    m_stderr.flush();
-    m_stderr.close();
-  }
-  if(m_stdlog.is_open())
-  {
-    m_stdlog.flush();
-    m_stderr.close();
-  }
-  if(m_stdin.is_open())
-  {
-    m_stdin.close();
-  }
 #ifdef _WIN32
   if(has_allocated_console) FreeConsole();
 #else

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -75,11 +75,7 @@ void Term::Terminal::store_and_restore()
     enabled = false;
   }
 #else
-  #if defined(__mips__) || defined(__mips) || defined(__MIPS__)
-  static termios orig_termios{0, 0, 0, 0, 0, {}};
-  #else
-  static termios orig_termios{0, 0, 0, 0, 0, {}, 0, 0};
-  #endif
+  static termios orig_termios;
   if(!enabled)
   {
     int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
@@ -117,11 +113,7 @@ void Term::Terminal::setRawMode()
   int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
   if(fd >= 0)
   {
-  #if defined(__mips__) || defined(__mips) || defined(__MIPS__)
-    static termios raw{0, 0, 0, 0, 0, {}};
-  #else
-    static termios raw{0, 0, 0, 0, 0, {}, 0, 0};
-  #endif
+    termios raw;
     if(tcgetattr(fd, &raw) == -1) { throw Term::Exception("tcgetattr() failed"); }
     // Put terminal in raw mode
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -75,7 +75,7 @@ void Term::Terminal::store_and_restore()
     enabled = false;
   }
 #else
-  static termios orig_termios{};
+  static termios orig_termios{0, 0, 0, 0, 0, {0}, 0, 0};
   if(!enabled)
   {
     int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
@@ -113,7 +113,7 @@ void Term::Terminal::setRawMode()
   int fd{open("/dev/tty", O_RDWR, O_NOCTTY)};
   if(fd >= 0)
   {
-    termios raw{};
+    termios raw{0, 0, 0, 0, 0, {0}, 0, 0};
     if(tcgetattr(fd, &raw) == -1) { throw Term::Exception("tcgetattr() failed"); }
     // Put terminal in raw mode
     raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);

--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -115,7 +115,6 @@ Term::Result Term::prompt(const std::string& message, const std::string& first_o
       }
     }
   }
-  return Result::INVALID;
 }
 
 Term::Result_simple Term::prompt_simple(const std::string& message)

--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -126,10 +126,9 @@ Term::Result_simple Term::prompt_simple(const std::string& message)
     case Result::NO:     // falls through
     case Result::ERROR:  // falls through
     case Result::NONE:   // falls through
-    case Result::INVALID: return Result_simple::NO;
+    case Result::INVALID:
+    default: return Result_simple::NO;
   }
-  // shouldn't be reached
-  return Result_simple::NO;
 }
 
 std::string Term::concat(const std::vector<std::string>& lines)
@@ -164,14 +163,14 @@ char32_t UU(const std::string& s)
   return s2[0];
 }
 
-void Term::print_left_curly_bracket(Term::Window& scr, int x, int y1, int y2)
+void Term::print_left_curly_bracket(Term::Window& scr, const std::size_t& x, const std::size_t& y1, const std::size_t& y2)
 {
-  int h = y2 - y1 + 1;
+  std::size_t h{y2 - y1 + 1};
   if(h == 1) { scr.set_char(x, y1, UU("]")); }
   else
   {
     scr.set_char(x, y1, UU("┐"));
-    for(int j = y1 + 1; j <= y2 - 1; j++) { scr.set_char(x, j, UU("│")); }
+    for(std::size_t j = y1 + 1; j <= y2 - 1; j++) { scr.set_char(x, j, UU("│")); }
     scr.set_char(x, y2, UU("┘"));
   }
 }

--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -328,7 +328,6 @@ std::string Term::prompt_multiline(const std::string& prompt_string, std::vector
           }
           break;
         case Key::CTRL_N:
-        case Key::ALT + Key::ENTER:
         {
           std::string before        = m.lines[m.cursor_row - 1].substr(0, m.cursor_col - 1);
           std::string after         = m.lines[m.cursor_row - 1].substr(m.cursor_col - 1);

--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -12,7 +12,7 @@
 
 Term::Result Term::prompt(const std::string& message, const std::string& first_option, const std::string& second_option, const std::string& prompt_indicator, bool immediate)
 {
-  Terminal term({Option::NoClearScreen, Option::NoSignalKeys, Option::Cursor});
+  Term::terminal.setOptions({Option::NoClearScreen, Option::NoSignalKeys, Option::Cursor, Term::Option::Raw});
   std::cout << message << " [" << first_option << '/' << second_option << ']' << prompt_indicator << ' ' << std::flush;
 
   if(!Term::is_stdin_a_tty())

--- a/cpp-terminal/prompt.hpp
+++ b/cpp-terminal/prompt.hpp
@@ -67,7 +67,7 @@ std::string concat(const std::vector<std::string>&);
 
 std::vector<std::string> split(const std::string&);
 
-void print_left_curly_bracket(Term::Window&, int, int, int);
+void print_left_curly_bracket(Term::Window&, const std::size_t&, const std::size_t&, const std::size_t&);
 
 void render(Term::Window&, const Model&, const std::size_t&);
 

--- a/cpp-terminal/screen.cpp
+++ b/cpp-terminal/screen.cpp
@@ -13,14 +13,14 @@ bool Term::Screen::empty()
 
 std::pair<std::size_t, std::size_t> Term::Screen::size() { return m_size; }
 
-std::string Term::clear_screen() { return "\033[2J"; }
+std::string Term::clear_screen() { return "\x1b[2J"; }
 
 std::string Term::screen_save()
 {
-  return "\0337\033[?1049h";  // save current cursor position, save screen
+  return "\x1b""7\x1b[?1049h";  // save current cursor position, save screen
 }
 
 std::string Term::screen_load()
 {
-  return "\033[?1049l\0338";  // restores screen, restore current cursor position
+  return "\x1b[?1049l\x1b""8";  // restores screen, restore current cursor position
 }

--- a/cpp-terminal/screen.cpp
+++ b/cpp-terminal/screen.cpp
@@ -17,10 +17,10 @@ std::string Term::clear_screen() { return "\x1b[2J"; }
 
 std::string Term::screen_save()
 {
-  return "\x1b""7\x1b[?1049h";  // save current cursor position, save screen
+  return "\0337\033[?1049h";  // save current cursor position, save screen
 }
 
 std::string Term::screen_load()
 {
-  return "\x1b[?1049l\x1b""8";  // restores screen, restore current cursor position
+  return "\033[?1049l\0338";  // restores screen, restore current cursor position
 }

--- a/cpp-terminal/screen.hpp
+++ b/cpp-terminal/screen.hpp
@@ -1,4 +1,3 @@
-
 #pragma once
 
 #include <string>

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -15,8 +15,8 @@ Term::Terminal::Terminal()
 
 Term::Terminal::~Terminal()
 {
-  // if(m_options.has(Option::ClearScreen)) Term::clog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
-  // if(m_options.has(Option::NoCursor)) Term::clog << cursor_on();
+  if(m_options.has(Option::ClearScreen)) Term::clog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
+  if(m_options.has(Option::NoCursor)) Term::clog << cursor_on();
   store_and_restore();
   detachConsole();
 }
@@ -24,8 +24,8 @@ Term::Terminal::~Terminal()
 void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
 {
   m_options = options;
-  // if(m_options.has(Option::ClearScreen)) Term::clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
-  // if(m_options.has(Option::NoCursor)) Term::clog << cursor_off();
+  if(m_options.has(Option::ClearScreen)) Term::clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
+  if(m_options.has(Option::NoCursor)) Term::clog << cursor_off();
   if(m_options.has(Option::Raw)) setRawMode();
 }
 

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -1,7 +1,11 @@
 #include "cpp-terminal/terminal.hpp"
+
 #include "cpp-terminal/cursor.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
+
+#include <fstream>
 
 Term::Terminal::Terminal()
 {
@@ -11,8 +15,8 @@ Term::Terminal::Terminal()
 
 Term::Terminal::~Terminal()
 {
-  if(m_options.has(Option::ClearScreen)) m_stdlog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
-  if(m_options.has(Option::NoCursor)) m_stdlog << cursor_on();
+  // if(m_options.has(Option::ClearScreen)) Term::clog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
+  // if(m_options.has(Option::NoCursor)) Term::clog << cursor_on();
   store_and_restore();
   detachConsole();
 }
@@ -20,8 +24,8 @@ Term::Terminal::~Terminal()
 void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
 {
   m_options = options;
-  if(m_options.has(Option::ClearScreen)) m_stdlog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
-  if(m_options.has(Option::NoCursor)) m_stdlog << cursor_off();
+  // if(m_options.has(Option::ClearScreen)) Term::clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
+  // if(m_options.has(Option::NoCursor)) Term::clog << cursor_off();
   if(m_options.has(Option::Raw)) setRawMode();
 }
 

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -6,18 +6,10 @@
 
 #include <iostream>
 
-Term::Terminal::Terminal(const std::vector<Term::Options::Option>& options) : m_options(options)
+Term::Terminal::Terminal()
 {
   attachConsole();
   store_and_restore();
-  setRawMode();
-  if(m_options.has(Option::ClearScreen))
-  {
-    // Fix consoles that ignore save_screen()
-    std::cout << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
-  }
-  if(m_options.has(Option::NoCursor)) std::cout << cursor_off();
-  std::cout << std::flush;
 }
 
 Term::Terminal::~Terminal()
@@ -32,6 +24,20 @@ Term::Terminal::~Terminal()
   std::cout << std::flush;
   detachConsole();
   store_and_restore();
+}
+
+void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
+{
+  m_options = options;
+  if(m_options.has(Option::Raw)) setRawMode();
+  if(m_options.has(Option::ClearScreen))
+  {
+    // Fix consoles that ignore save_screen()
+    std::cout << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
+  }
+  if(m_options.has(Option::NoCursor)) std::cout << cursor_off();
+  std::cout << std::flush;
+  std::cout << "DONE" << std::endl;
 }
 
 std::string Term::terminal_title(const std::string& title) { return "\033]0;" + title + '\a'; }

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -1,31 +1,30 @@
 #include "cpp-terminal/terminal.hpp"
 
 #include "cpp-terminal/cursor.hpp"
-#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
-
-#include <fstream>
 
 Term::Terminal::Terminal()
 {
   attachConsole();
+  attachStreams();
   store_and_restore();
 }
 
 Term::Terminal::~Terminal()
 {
-  if(m_options.has(Option::ClearScreen)) Term::clog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
-  if(m_options.has(Option::NoCursor)) Term::clog << cursor_on();
+  if(m_options.has(Option::ClearScreen)) clog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
+  if(m_options.has(Option::NoCursor)) clog << cursor_on();
   store_and_restore();
+  detachStreams();
   detachConsole();
 }
 
 void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
 {
   m_options = options;
-  if(m_options.has(Option::ClearScreen)) Term::clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
-  if(m_options.has(Option::NoCursor)) Term::clog << cursor_off();
+  if(m_options.has(Option::ClearScreen)) clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
+  if(m_options.has(Option::NoCursor)) clog << cursor_off();
   if(m_options.has(Option::Raw)) setRawMode();
 }
 

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -3,6 +3,7 @@
 #include "cpp-terminal/cursor.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
+#include "options.hpp"
 
 Term::Terminal::Terminal()
 {
@@ -22,7 +23,7 @@ Term::Terminal::~Terminal()
 
 void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
 {
-  m_options = options;
+  m_options = Options(options);
   if(m_options.has(Option::ClearScreen)) clog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
   if(m_options.has(Option::NoCursor)) clog << cursor_off();
   if(m_options.has(Option::Raw)) setRawMode();

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -1,10 +1,7 @@
 #include "cpp-terminal/terminal.hpp"
-
 #include "cpp-terminal/cursor.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
-
-#include <iostream>
 
 Term::Terminal::Terminal()
 {
@@ -14,30 +11,18 @@ Term::Terminal::Terminal()
 
 Term::Terminal::~Terminal()
 {
-  if(m_options.has(Option::ClearScreen))
-  {
-    // Fix consoles that ignore save_screen()
-    std::cout << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load() << std::flush;
-  }
-  if(m_options.has(Option::NoCursor)) std::cout << cursor_on() << std::flush;
-  // flush the output stream
-  std::cout << std::flush;
-  detachConsole();
+  if(m_options.has(Option::ClearScreen)) m_stdlog << clear_buffer() << style(Style::RESET) << cursor_move(1, 1) << screen_load();
+  if(m_options.has(Option::NoCursor)) m_stdlog << cursor_on();
   store_and_restore();
+  detachConsole();
 }
 
 void Term::Terminal::setOptions(const std::vector<Term::Options::Option>& options)
 {
   m_options = options;
+  if(m_options.has(Option::ClearScreen)) m_stdlog << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
+  if(m_options.has(Option::NoCursor)) m_stdlog << cursor_off();
   if(m_options.has(Option::Raw)) setRawMode();
-  if(m_options.has(Option::ClearScreen))
-  {
-    // Fix consoles that ignore save_screen()
-    std::cout << screen_save() << clear_buffer() << style(Style::RESET) << cursor_move(1, 1);
-  }
-  if(m_options.has(Option::NoCursor)) std::cout << cursor_off();
-  std::cout << std::flush;
-  std::cout << "DONE" << std::endl;
 }
 
 std::string Term::terminal_title(const std::string& title) { return "\033]0;" + title + '\a'; }

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -33,7 +33,6 @@ public:
       std::vector<Term::Options::Option> option = m_options.getOptions();
       store_and_restore();
       this->cin >> dt;
-      m_options = option;
       store_and_restore();
       setOptions(option);
       return this->cin;

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -3,7 +3,6 @@
 #include "cpp-terminal/io.hpp"
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminfo.hpp"
-#include "cpp-terminal/tty.hpp"
 
 #include <fstream>
 

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminfo.hpp"
 
@@ -18,8 +19,9 @@ namespace Term
 class Terminal
 {
 public:
-  Terminal(const std::vector<Term::Options::Option>& options = {});
+  Terminal();
   ~Terminal();
+  void setOptions(const std::vector<Term::Options::Option>& options = {});
 
 private:
   FILE*          m_stdin{nullptr};

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -4,7 +4,7 @@
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminfo.hpp"
 
-#include <cstdio>
+#include <fstream>
 #include <string>
 
 namespace Term
@@ -24,9 +24,10 @@ public:
   void setOptions(const std::vector<Term::Options::Option>& options = {});
 
 private:
-  FILE*          m_stdin{nullptr};
-  FILE*          m_stdout{nullptr};
-  FILE*          m_stderr{nullptr};
+  std::ofstream  m_stdout;
+  std::ofstream  m_stderr;
+  std::ofstream  m_stdlog;
+  std::ifstream  m_stdin;
   void           store_and_restore();
   void           setRawMode();
   void           attachConsole();

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -3,8 +3,9 @@
 #include "cpp-terminal/io.hpp"
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminfo.hpp"
+#include "cpp-terminal/tty.hpp"
 
-#include <string>
+#include <fstream>
 
 namespace Term
 {
@@ -20,13 +21,47 @@ class Terminal
 public:
   Terminal();
   ~Terminal();
-  void setOptions(const std::vector<Term::Options::Option>& options = {});
+  void                           setOptions(const std::vector<Term::Options::Option>& options = {});
+  template<typename T> Terminal& operator<<(const T& dt)
+  {
+    clog << dt;
+    return *this;
+  }
+  template<typename T> std::istream& operator>>(T& dt)
+  {
+    if(m_options.has(Options::Option::Raw))
+    {
+      std::vector<Term::Options::Option> option = m_options.getOptions();
+      store_and_restore();
+      this->cin >> dt;
+      m_options = option;
+      store_and_restore();
+      setOptions(option);
+      return this->cin;
+    }
+    else
+    {
+      this->cin >> dt;
+      return this->cin;
+    }
+  }
+  Terminal& operator<<(std::ostream& (*fun)(std::ostream&))
+  {
+    clog << fun;
+    return *this;
+  }
 
 private:
+  std::ofstream  cout;
+  std::ofstream  cerr;
+  std::ofstream  clog;
+  std::ifstream  cin;
   void           store_and_restore();
   void           setRawMode();
   void           attachConsole();
   void           detachConsole();
+  void           attachStreams();
+  void           detachStreams();
   bool           has_allocated_console{false};
   Term::Terminfo m_terminfo;
   Term::Options  m_options;

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -4,7 +4,6 @@
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminfo.hpp"
 
-#include <fstream>
 #include <string>
 
 namespace Term
@@ -24,10 +23,6 @@ public:
   void setOptions(const std::vector<Term::Options::Option>& options = {});
 
 private:
-  std::ofstream  m_stdout;
-  std::ofstream  m_stderr;
-  std::ofstream  m_stdlog;
-  std::ifstream  m_stdin;
   void           store_and_restore();
   void           setRawMode();
   void           attachConsole();

--- a/cpp-terminal/version.cpp.in
+++ b/cpp-terminal/version.cpp.in
@@ -1,0 +1,9 @@
+#include "cpp-terminal/version.hpp"
+
+// clang-format off
+const int Term::VersionMajor{@cpp-terminal_VERSION_MAJOR@};
+const int Term::VersionMinor{@cpp-terminal_VERSION_MINOR@};
+const int Term::VersionPatch{@cpp-terminal_VERSION_PATCH@};
+const char* Term::Version{"@cpp-terminal_VERSION_MAJOR@.@cpp-terminal_VERSION_MINOR@.@cpp-terminal_VERSION_PATCH@"};
+const char* Term::Homepage{"@cpp-terminal_HOMEPAGE_URL@"};
+// clang-format on

--- a/cpp-terminal/version.hpp
+++ b/cpp-terminal/version.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// version
+namespace Term
+{
+extern const int   VersionMajor;
+extern const int   VersionMinor;
+extern const int   VersionPatch;
+extern const char* Version;
+extern const char* Homepage;
+}  // namespace Term

--- a/cpp-terminal/window.cpp
+++ b/cpp-terminal/window.cpp
@@ -294,6 +294,6 @@ std::string Term::Window::render(const std::size_t& x0, const std::size_t& y0, b
     out.append(cursor_on());
   }
   return out;
-};
+}
 
 }  // namespace Term

--- a/cpp-terminal/window.cpp
+++ b/cpp-terminal/window.cpp
@@ -4,8 +4,6 @@
 #include "cpp-terminal/exception.hpp"
 #include "cpp-terminal/platforms/conversion.hpp"
 
-#include <iostream>
-
 namespace Term
 {
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_executable(cin cin.cpp)
+target_link_libraries(cin PRIVATE cpp-terminal::cpp-terminal Warnings::Warnings)
+
 add_executable(minimal minimal.cpp)
 target_link_libraries(minimal PRIVATE cpp-terminal::cpp-terminal Warnings::Warnings)
 
@@ -32,5 +35,5 @@ add_executable(read_stdin read_stdin.cpp)
 target_link_libraries(read_stdin PRIVATE cpp-terminal::cpp-terminal Warnings::Warnings)
 
 if(CPPTERMINAL_ENABLE_INSTALL)
-  install(TARGETS prompt_multiline prompt_immediate prompt_not_immediate prompt_simple kilo menu menu_window keys colors read_stdin RUNTIME DESTINATION bin/examples)
+  install(TARGETS cin minimal prompt_multiline prompt_immediate prompt_not_immediate prompt_simple kilo menu menu_window keys colors read_stdin RUNTIME DESTINATION bin/examples)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,6 @@
+add_executable(minimal minimal.cpp)
+target_link_libraries(minimal PRIVATE cpp-terminal::cpp-terminal Warnings::Warnings)
+
 add_executable(prompt_multiline prompt_multiline.cpp)
 target_link_libraries(prompt_multiline PRIVATE cpp-terminal::cpp-terminal Warnings::Warnings)
 

--- a/examples/cin.cpp
+++ b/examples/cin.cpp
@@ -1,0 +1,23 @@
+#include "cpp-terminal/input.hpp"
+#include "cpp-terminal/terminal.hpp"
+
+#include <iostream>
+
+int main()
+{
+  Term::terminal.setOptions({Term::Option::Raw});
+  Term::terminal << "This should be printed" << std::flush << " only in terminal" << std::endl;
+  std::cout << "This should be printed in terminal if stdout is not redirected" << std::endl;
+  Term::terminal << "Now type a number and then a string !" << std::endl;
+  int         number;
+  std::string string;
+  Term::terminal >> number >> string;
+  std::cout << "Your number is " << number << " " << string << std::endl;
+  std::cout << "Now we are back to raw mode. Play with keys and press CTRL_C to quit." << std::endl;
+  Term::Key event;
+  while((event = Term::read_event()) != Term::Key(Term::Key::CTRL_C))
+  {
+    if(event.is_extended_ASCII()) Term::terminal << "You typed :" << static_cast<char>(event) << std::endl;
+  }
+  return 0;
+}

--- a/examples/colors.cpp
+++ b/examples/colors.cpp
@@ -1,5 +1,6 @@
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/exception.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/style.hpp"
 #include "cpp-terminal/tty.hpp"
 #include "cpp-terminal/version.hpp"

--- a/examples/colors.cpp
+++ b/examples/colors.cpp
@@ -1,7 +1,7 @@
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/exception.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/style.hpp"
-#include "cpp-terminal/terminal.hpp"
 #include "cpp-terminal/tty.hpp"
 #include "cpp-terminal/version.hpp"
 
@@ -13,7 +13,6 @@ int main()
 
   try
   {
-    Term::Terminal term;
     if(Term::is_stdout_a_tty()) { std::cout << "Standard output is attached to a terminal." << std::endl << std::endl; }
     else { std::cout << "Standard output is not attached to a terminal." << std::endl << std::endl; }
 

--- a/examples/colors.cpp
+++ b/examples/colors.cpp
@@ -1,6 +1,5 @@
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/exception.hpp"
-#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/style.hpp"
 #include "cpp-terminal/tty.hpp"
 #include "cpp-terminal/version.hpp"

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -3,13 +3,13 @@
 #include "cpp-terminal/input.hpp"
 #include "cpp-terminal/io.hpp"
 #include "cpp-terminal/key.hpp"
+#include "cpp-terminal/options.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/terminal.hpp"
 #include "cpp-terminal/tty.hpp"
 #include "cpp-terminal/version.hpp"
 
 #include <iostream>
-#include <utility>
 
 int main()
 {
@@ -21,7 +21,7 @@ int main()
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::terminal.setOptions({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor});
+    Term::terminal.setOptions({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor, Term::Option::Raw});
 
     Term::Cursor cursor{Term::cursor_position()};
     std::cout << "Cursor position : " << cursor.row() << " " << cursor.column() << std::endl;

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -121,6 +121,7 @@ int main()
             std::cout << ").\nPlease report key combination pressed to " << Term::Homepage << std::endl;
           }
         }
+        default: break;
       }
     }
   }

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -1,6 +1,7 @@
 #include "cpp-terminal/cursor.hpp"
 #include "cpp-terminal/exception.hpp"
 #include "cpp-terminal/input.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/key.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/terminal.hpp"
@@ -20,7 +21,7 @@ int main()
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::Terminal term({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor});
+    Term::terminal.setOptions({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor});
 
     Term::Cursor cursor{Term::cursor_position()};
     std::cout << "Cursor position : " << cursor.row() << " " << cursor.column() << std::endl;

--- a/examples/kilo.cpp
+++ b/examples/kilo.cpp
@@ -2,6 +2,7 @@
 #include "cpp-terminal/exception.hpp"
 #include "cpp-terminal/input.hpp"
 #include "cpp-terminal/key.hpp"
+#include "cpp-terminal/options.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
 #include "cpp-terminal/terminal.hpp"
@@ -925,7 +926,7 @@ int main(int argc, char* argv[])
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::Terminal term({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor});
+    Term::terminal.setOptions({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor, Term::Option::Raw});
     initEditor();
     if(argc >= 2) { editorOpen(argv[1]); }
 

--- a/examples/menu.cpp
+++ b/examples/menu.cpp
@@ -1,6 +1,7 @@
 #include "cpp-terminal/color.hpp"
 #include "cpp-terminal/exception.hpp"
 #include "cpp-terminal/input.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/key.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
@@ -75,7 +76,7 @@ int main()
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::Terminal term({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor});
+    Term::terminal.setOptions({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor, Term::Option::Raw});
     Term::Screen   term_size = Term::screen_size();
     int            pos       = 5;
     int            h         = 10;

--- a/examples/menu.cpp
+++ b/examples/menu.cpp
@@ -77,11 +77,11 @@ int main()
       return 1;
     }
     Term::terminal.setOptions({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor, Term::Option::Raw});
-    Term::Screen   term_size = Term::screen_size();
-    int            pos       = 5;
-    int            h         = 10;
-    std::size_t    w{10};
-    bool           on = true;
+    Term::Screen term_size = Term::screen_size();
+    int          pos       = 5;
+    int          h         = 10;
+    std::size_t  w{10};
+    bool         on = true;
     while(on)
     {
       render(term_size.rows(), term_size.columns(), h, w, pos);

--- a/examples/menu.cpp
+++ b/examples/menu.cpp
@@ -108,6 +108,7 @@ int main()
             case Term::Key::q:
             case Term::Key::ESC:
             case Term::Key::CTRL_C: on = false; break;
+            default: break;
           }
           break;
         case Term::Event::Type::Screen:
@@ -115,6 +116,7 @@ int main()
           std::cout << Term::clear_screen() << std::flush;
           render(term_size.rows(), term_size.columns(), h, w, pos);
           break;
+        default: break;
       }
     }
   }

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -52,12 +52,12 @@ int main()
       return 1;
     }
     Term::terminal.setOptions({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor, Term::Option::Raw});
-    Term::Screen   term_size = Term::screen_size();
-    int            pos       = 5;
-    int            h         = 10;
-    std::size_t    w{10};
-    bool           on = true;
-    Term::Window   scr(term_size.columns(), term_size.rows());
+    Term::Screen term_size = Term::screen_size();
+    int          pos       = 5;
+    int          h         = 10;
+    std::size_t  w{10};
+    bool         on = true;
+    Term::Window scr(term_size.columns(), term_size.rows());
     while(on)
     {
       std::cout << render(scr, term_size.rows(), term_size.columns(), h, w, pos) << std::flush;

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -51,7 +51,7 @@ int main()
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::Terminal term({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor});
+    Term::terminal.setOptions({Term::Option::ClearScreen, Term::Option::NoSignalKeys, Term::Option::NoCursor, Term::Option::Raw});
     Term::Screen   term_size = Term::screen_size();
     int            pos       = 5;
     int            h         = 10;

--- a/examples/menu_window.cpp
+++ b/examples/menu_window.cpp
@@ -81,6 +81,7 @@ int main()
         case Term::Key::q:
         case Term::Key::ESC:
         case Term::Key::CTRL_C: on = false; break;
+        default: break;
       }
     }
   }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -1,23 +1,9 @@
-#include "cpp-terminal/input.hpp"
-#include "cpp-terminal/terminal.hpp"
+#include "cpp-terminal/io.hpp"
 
 #include <iostream>
 
 int main()
 {
-  Term::terminal.setOptions({Term::Option::Raw});
-  Term::terminal << "This should be printed" << std::flush << " only in terminal" << std::endl;
-  std::cout << "This should be printed in terminal if stdout is not redirected" << std::endl;
-  Term::terminal << "Now type a number and then a string !" << std::endl;
-  int         number;
-  std::string string;
-  Term::terminal >> number >> string;
-  std::cout << "Your number is " << number << " " << string << std::endl;
-  std::cout << "Now we are back to raw mode. Play with keys and press CTRL_C to quit." << std::endl;
-  Term::Key event;
-  while((event = Term::read_event()) != Term::Key(Term::Key::CTRL_C))
-  {
-    if(event.is_extended_ASCII()) Term::terminal << "You typed :" << static_cast<char>(event) << std::endl;
-  }
+  std::cout << "Just including io.hpp activate \033[31mcolor\033[0m !" << std::endl;
   return 0;
 }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -1,7 +1,4 @@
-#include "cpp-terminal/event.hpp"
 #include "cpp-terminal/input.hpp"
-#include "cpp-terminal/io.hpp"
-#include "cpp-terminal/options.hpp"
 #include "cpp-terminal/terminal.hpp"
 
 #include <iostream>

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -5,5 +5,7 @@
 int main()
 {
   std::cout << "Just including io.hpp activate \033[31mcolor\033[0m !" << std::endl;
+  int i{0};
+  std::cin>>i;
   return 0;
 }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -1,10 +1,26 @@
+#include "cpp-terminal/event.hpp"
+#include "cpp-terminal/input.hpp"
 #include "cpp-terminal/io.hpp"
+#include "cpp-terminal/options.hpp"
+#include "cpp-terminal/terminal.hpp"
 
-#include <fstream>
 #include <iostream>
 
 int main()
 {
-  Term::cout << "This should be printed only in terminal" << std::endl;
+  Term::terminal.setOptions({Term::Option::Raw});
+  Term::terminal << "This should be printed" << std::flush << " only in terminal" << std::endl;
   std::cout << "This should be printed in terminal if stdout is not redirected" << std::endl;
+  Term::terminal << "Now type a number and then a string !" << std::endl;
+  int         number;
+  std::string string;
+  Term::terminal >> number >> string;
+  std::cout << "Your number is " << number << " " << string << std::endl;
+  std::cout << "Now we are back to raw mode. Play with keys and press CTRL_C to quit." << std::endl;
+  Term::Key event;
+  while((event = Term::read_event()) != Term::Key(Term::Key::CTRL_C))
+  {
+    if(event.is_extended_ASCII()) Term::terminal << "You typed :" << static_cast<char>(event) << std::endl;
+  }
+  return 0;
 }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -1,3 +1,10 @@
 #include "cpp-terminal/io.hpp"
 
-int main() { Term::terminal; }
+#include <fstream>
+#include <iostream>
+
+int main()
+{
+  Term::cout << "This should be printed only in terminal" << std::endl;
+  std::cout << "This should be printed in terminal if stdout is not redirected" << std::endl;
+}

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -1,0 +1,3 @@
+#include "cpp-terminal/io.hpp"
+
+int main() { Term::terminal; }

--- a/examples/minimal.cpp
+++ b/examples/minimal.cpp
@@ -6,6 +6,6 @@ int main()
 {
   std::cout << "Just including io.hpp activate \033[31mcolor\033[0m !" << std::endl;
   int i{0};
-  std::cin>>i;
+  std::cin >> i;
   return 0;
 }

--- a/examples/prompt_multiline.cpp
+++ b/examples/prompt_multiline.cpp
@@ -33,7 +33,7 @@ int main()
               << "  * Features:\n"
               << "    - Editing (Keys: Left, Right, Home, End, Backspace)\n"
               << "    - History (Keys: Up, Down)\n"
-              << "    - Multi-line editing (use Alt-Enter to add a new line)" << std::endl;
+              << "    - Multi-line editing (use CTRL+N to add a new line)" << std::endl;
     // TODO:
     // std::cout << "    - Syntax highlighting" << std::endl;
     std::vector<std::string>         history;

--- a/examples/prompt_multiline.cpp
+++ b/examples/prompt_multiline.cpp
@@ -1,4 +1,5 @@
 #include "cpp-terminal/exception.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/key.hpp"
 #include "cpp-terminal/prompt.hpp"
 #include "cpp-terminal/tty.hpp"
@@ -25,7 +26,7 @@ int main()
       std::cout << "The terminal is not attached to a TTY and therefore can't catch user input. Exiting...\n";
       return 1;
     }
-    Term::Terminal term({Term::Option::NoClearScreen, Term::Option::SignalKeys, Term::Option::Cursor});
+    Term::terminal.setOptions({Term::Option::NoClearScreen, Term::Option::SignalKeys, Term::Option::Cursor, Term::Option::Raw});
     std::cout << "Interactive prompt.\n"
               << "  * Use Ctrl-D to exit.\n"
               << "  * Use Enter to submit.\n"

--- a/examples/prompt_multiline.cpp
+++ b/examples/prompt_multiline.cpp
@@ -4,7 +4,6 @@
 #include "cpp-terminal/prompt.hpp"
 #include "cpp-terminal/tty.hpp"
 
-#include <functional>
 #include <iostream>
 #include <string>
 #include <vector>

--- a/examples/read_stdin.cpp
+++ b/examples/read_stdin.cpp
@@ -1,4 +1,5 @@
 #include "cpp-terminal/input.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/terminal.hpp"
 #include "cpp-terminal/tty.hpp"
 
@@ -6,6 +7,6 @@
 
 int main()
 {
-  Term::Terminal term({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor});
+  Term::terminal.setOptions({Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor, Term::Option::Raw});
   std::cout << "Input from stdin: " << Term::read_stdin() << std::endl;
 }

--- a/examples/read_stdin.cpp
+++ b/examples/read_stdin.cpp
@@ -1,7 +1,6 @@
 #include "cpp-terminal/input.hpp"
 #include "cpp-terminal/io.hpp"
 #include "cpp-terminal/terminal.hpp"
-#include "cpp-terminal/tty.hpp"
 
 #include <iostream>
 

--- a/tests/attach_console.test.cpp
+++ b/tests/attach_console.test.cpp
@@ -12,7 +12,7 @@
 #include <iostream>
 
 #ifdef _WIN32
-int WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR cmdline, int show)
+int __stdcall WinMain(HINSTANCE hinst, HINSTANCE hprev, LPSTR cmdline, int show)
 #else
 int main()
 #endif
@@ -21,7 +21,6 @@ int main()
 
   try
   {
-    Term::Terminal term;
     if(Term::is_stdout_a_tty()) { std::cout << "Standard output is attached to a terminal." << std::endl << std::endl; }
     else { std::cout << "Standard output is not attached to a terminal." << std::endl << std::endl; }
 


### PR DESCRIPTION
Sorry for the big number of commits but I have to move from Linux to Windows and these changes are quite profound.

Mainly : 
1) Fix #32 : But it uses https://en.wikibooks.org/wiki/More_C%2B%2B_Idioms/Nifty_Counter. This requires constructor without parameters. So a big refactoring was needed but I think it makes the class more logical (to me :)). It would be very nice for people who just want to activate ANSII Escape code without relying on the all library. I can't imagine a more simplier .hpp :)
```cpp
#pragma once

namespace Term
{

class Terminal;
extern Terminal& terminal;

class Initializer
{
public:
  Initializer();
  ~Initializer();

private:
  static int m_counter;
};

static Initializer m_Initializer;

}  // namespace Term
```
NOT more. 

including the line mentioned 'io.hpp' (I know the name is ugly) and linking to cpp-terminal allows to have a minimal terminal setup. It turn ON ANSII escape code in windows etc without adding nothing in the code (see examples/minimal.cpp) and restore the old state when quiting. This lightweight version could interest many people I think. 

2) Allow to use Term::terminal<< or Term::terminal>> adding "terminal.hpp" (see examples/cin.cpp) This operator always read, write to console (even if stdin stdout as been redirected)

3) By default the terminal is no Cooked you need to explicitly turn it into RawMode (see examples/cin.cpp etc...). It was necessary to allow 1)

Cleaning, warning fixes etc...

An other PR will follow with futher cleaning (2nd Nifty_Counter to avoid open/close file handlers and simplify code). 