### PR TITLE
Badstate  (Fix #248)

### DIFF
--- a/cpp-terminal/platforms/CMakeLists.txt
+++ b/cpp-terminal/platforms/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(cpp-terminal-platforms STATIC terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp file.cpp)
+add_library(cpp-terminal-platforms STATIC terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp file.cpp env.cpp)
 target_link_libraries(cpp-terminal-platforms PRIVATE Warnings::Warnings)
 target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8 /wd4668 /wd4514>)
 target_include_directories(cpp-terminal-platforms PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)

--- a/cpp-terminal/platforms/env.cpp
+++ b/cpp-terminal/platforms/env.cpp
@@ -1,0 +1,18 @@
+#include "cpp-terminal/platforms/env.hpp"
+
+std::pair<bool, std::string> Term::Private::getenv(const std::string& env)
+{
+#ifdef _WIN32
+  std::size_t requiredSize{0};
+  getenv_s(&requiredSize, nullptr, 0, env.c_str());
+  if(requiredSize == 0) return {false, std::string()};
+  std::string ret;
+  ret.reserve(requiredSize * sizeof(char));
+  getenv_s(&requiredSize, &ret[0], requiredSize, env.c_str());
+  return {true, ret};
+#else
+  if(std::getenv(env.c_str()) != nullptr) return {true, static_cast<std::string>(std::getenv(env.c_str()))};
+  else
+    return {false, std::string()};
+#endif
+}

--- a/cpp-terminal/platforms/env.hpp
+++ b/cpp-terminal/platforms/env.hpp
@@ -1,0 +1,17 @@
+// This header should be used only in files contains inside platforms folder !!!
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace Term
+{
+
+namespace Private
+{
+
+std::pair<bool, std::string> getenv(const std::string& env);
+
+}
+
+}  // namespace Term

--- a/cpp-terminal/platforms/env.hpp
+++ b/cpp-terminal/platforms/env.hpp
@@ -10,6 +10,13 @@ namespace Term
 namespace Private
 {
 
+ /**
+ * @brief Value of an environment variables.
+ *
+ * @param env environment variable.
+ * @return std::pair<bool, std::string> with bool:true if the environment variable is set and std::string to the value of environment variable.
+ * @warning Internal use only.
+ */
 std::pair<bool, std::string> getenv(const std::string& env);
 
 }

--- a/cpp-terminal/platforms/env.hpp
+++ b/cpp-terminal/platforms/env.hpp
@@ -10,15 +10,15 @@ namespace Term
 namespace Private
 {
 
- /**
- * @brief Value of an environment variables.
- *
- * @param env environment variable.
- * @return std::pair<bool, std::string> with bool:true if the environment variable is set and std::string to the value of environment variable.
- * @warning Internal use only.
- */
+/**
+* @brief Value of an environment variables.
+*
+* @param env environment variable.
+* @return std::pair<bool, std::string> with bool:true if the environment variable is set and std::string to the value of environment variable.
+* @warning Internal use only.
+*/
 std::pair<bool, std::string> getenv(const std::string& env);
 
-}
+} // namespace Private
 
 }  // namespace Term

--- a/cpp-terminal/platforms/env.hpp
+++ b/cpp-terminal/platforms/env.hpp
@@ -1,4 +1,4 @@
-// This header should be used only in files contains inside platforms folder !!!
+// This header should be used only in files contained inside platforms folder !!!
 #pragma once
 
 #include <string>

--- a/cpp-terminal/platforms/env.hpp
+++ b/cpp-terminal/platforms/env.hpp
@@ -19,6 +19,6 @@ namespace Private
 */
 std::pair<bool, std::string> getenv(const std::string& env);
 
-} // namespace Private
+}  // namespace Private
 
 }  // namespace Term

--- a/cpp-terminal/platforms/terminal.cpp
+++ b/cpp-terminal/platforms/terminal.cpp
@@ -1,6 +1,7 @@
 #include "cpp-terminal/terminal.hpp"
 
 #include "cpp-terminal/exception.hpp"
+#include "cpp-terminal/platforms/env.hpp"
 #include "cpp-terminal/platforms/file.hpp"
 
 #ifdef _WIN32
@@ -73,6 +74,19 @@ void Term::Terminal::store_and_restore()
     enabled = false;
   }
 #endif
+}
+
+void Term::Terminal::setBadStateReturnCode()
+{
+  std::pair<bool, std::string> returnCode{Private::getenv("CPP_TERMINAL_BADSTATE")};
+  try
+  {
+    if(returnCode.first && stoi(returnCode.second) != EXIT_SUCCESS) m_badReturnCode = stoi(returnCode.second);
+  }
+  catch(...)
+  {
+    m_badReturnCode = EXIT_FAILURE;
+  }
 }
 
 void Term::Terminal::setRawMode()

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -8,7 +8,6 @@
 #include "cpp-terminal/style.hpp"
 
 #include <exception>
-#include <iostream>
 
 Term::Terminal::Terminal()
 {

--- a/cpp-terminal/terminal.cpp
+++ b/cpp-terminal/terminal.cpp
@@ -1,11 +1,11 @@
 #include "cpp-terminal/terminal.hpp"
 
 #include "cpp-terminal/cursor.hpp"
+#include "cpp-terminal/exception.hpp"
+#include "cpp-terminal/io.hpp"
 #include "cpp-terminal/options.hpp"
 #include "cpp-terminal/screen.hpp"
 #include "cpp-terminal/style.hpp"
-#include "exception.hpp"
-#include "io.hpp"
 
 #include <exception>
 #include <iostream>

--- a/cpp-terminal/terminal.hpp
+++ b/cpp-terminal/terminal.hpp
@@ -58,6 +58,7 @@ public:
   }
 
 private:
+  void           setBadStateReturnCode();
   void           setOptions();
   void           applyOptions();
   std::ofstream  cout;
@@ -73,6 +74,7 @@ private:
   bool           has_allocated_console{false};
   Term::Terminfo m_terminfo;
   Term::Options  m_options;
+  std::uint8_t   m_badReturnCode{EXIT_FAILURE};
 };
 
 // change the title of the terminal, only supported by a few terminals

--- a/examples/keys.cpp
+++ b/examples/keys.cpp
@@ -16,7 +16,6 @@ int main()
     // check if the terminal is capable of handling input
     Term::terminal.setOptions(Term::Option::NoClearScreen, Term::Option::NoSignalKeys, Term::Option::Cursor, Term::Option::Raw);
     if(!Term::is_stdin_a_tty()) throw Term::Exception("The terminal is not attached to a TTY and therefore can't catch user input. Exiting...");
-
     Term::Cursor cursor{Term::cursor_position()};
     Term::terminal << "Cursor position : " << cursor.row() << " " << cursor.column() << std::endl;
 


### PR DESCRIPTION
This PR fix #248 by doing : 
1) All the exceptions in the destructor are catched inside it to avoid the exception to leak...
2) A message is printed to say the terminal is not in good state with reasons if possible
3) Return EXIT_FAILURE to the parent or the value given by the environment variable CPP_TERMINAL_BADSTATE if it can be casted to int otherwise return the default value (EXIT_FAILURE). It is possible to do:

UNIX :
```bash
./examples/keys ; echo $?
``` 
Windows : 
```cmd
.\examples\keys
echo %errorlevel%
```
to check if the terminal is in good mode.

I think it's the safest way to avoid crash and to let the user know something bad happened and to perform correction if he can/want/should.\

Global variable was impossible because the terminal is destroyed after the main ends so the value was ureachable. Which IMHO is nice because user don't have to worry to much if/when/where the terminal instance was created. Maybe the best should be to hide totally the terminal class to user to avoid him to instantiate an other one ?

