### PR TITLE
String performance

### DIFF
--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -1,8 +1,5 @@
 #include "cpp-terminal/cursor.hpp"
 
-// C++ libs
-#include <cstdlib> // for integer to string conversions 
-
 Term::Cursor::Cursor(const std::size_t& row, const std::size_t& column) : m_position({row, column}) {}
 
 std::size_t Term::Cursor::row() const { return m_position.first; }

--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -20,20 +20,20 @@ void Term::Cursor::setRow(const std::size_t& row) { m_position.first = row; }
 
 void Term::Cursor::setColum(const std::size_t& column) { m_position.second = column; }
 
-void Term::cursor_off(std::string& stringOut) { stringOut.append("\x1b[?25l"); }
+void Term::cursor_off(std::string& stringOut) { stringOut.append("\x1b[?25l", 9); }
 
 std::string Term::cursor_off() { return std::string("\x1b[?25l"); }
 
-void Term::cursor_on(std::string& stringOut) { stringOut.append("\x1b[?25h"); }
+void Term::cursor_on(std::string& stringOut) { stringOut.append("\x1b[?25h", 9); }
 
 std::string Term::cursor_on() { return std::string("\x1b[?25h"); }
 
-void Term::cursor_move(std::string stringOut&, std::size_t row, std::size_t column) { 	
-	stringOut.append("\x1b[");
-	stringOut.append(std::to_string(row));
-	stringOut.append(';');
-	stringOut.append(std::to_string(column));
-	stringOut.append('H');
+void Term::cursor_move(std::string& stringOut, std::size_t row, std::size_t column) { 	
+	stringOut.append("\x1b[", 5);
+	stringOut += std::to_string(row);
+	stringOut += ';';
+	stringOut += std::to_string(column);
+	stringOut += 'H';
  }
 
 std::string Term::cursor_move(std::size_t row, std::size_t column) { return "\x1b[" + std::to_string(row) + ';' + std::to_string(column) + 'H'; }
@@ -42,46 +42,46 @@ std::string Term::cursor_move(std::size_t row, std::size_t column) { return "\x1
 std::string Term::cursor_up(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'A'; }
 
 void Term::cursor_up(std::string& stringOut, std::size_t rows) { 
-	stringOut.append("\x1b[");
-	stringOut.append(std::to_string(rows));
-	stringOut.append('A');
+	stringOut.append("\x1b[", 5);
+	stringOut += std::to_string(rows);
+	stringOut += 'A';
 }
 
 std::string Term::cursor_down(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'B'; }
 
 void Term::cursor_down(std::string& stringOut, std::size_t rows) { 
-	stringOut.append("\x1b[");
-	stringOut.append(std::to_string(rows));
-	stringOut.append('B');
+	stringOut.append("\x1b[", 5);
+	stringOut += std::to_string(rows);
+	stringOut += 'B';
 }
 
 std::string Term::cursor_right(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'C'; }
 
 void Term::cursor_right(std::string& stringOut, std::size_t columns) { 
-	stringOut.append("\x1b[");
-	stringOut.append(std::to_string(columns));
-	stringOut.append('C');
+	stringOut.append("\x1b[", 5);
+	stringOut += std::to_string(columns);
+	stringOut += 'C';
 	
 }
 
 std::string Term::cursor_left(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'D'; }
 
 void Term::cursor_left(std::string& stringOut, std::size_t columns) { 
-	stringOut.append("\x1b[");
-	stringOut.append(std::to_string(columns));
-	stringOut.append('D');
+	stringOut.append("\x1b[", 5);
+	stringOut += std::to_string(columns);
+	stringOut += 'D';
 }
 
 std::string Term::cursor_position_report() { return "\x1b[6n"; }
 
-void Term::cursor_position_report(std::string& stringOut, ) { 
-	stringOut.append("\x1b[6n"); 
+void Term::cursor_position_report(std::string& stringOut) { 
+	stringOut.append("\x1b[6n", 7); 
 }
 
-std::string Term::clear_eol() { return "\x1b[K"; }
+std::string Term::clear_eol() { return std::string("\x1b[K"); }
 
-void Term::clear_eol(std::string& stringOut, ) { 
-	stringOut("\x1b[K");
+void Term::clear_eol(std::string& stringOut) { 
+	stringOut.append("\x1b[K", 6);
 }
 
 

--- a/cpp-terminal/cursor.cpp
+++ b/cpp-terminal/cursor.cpp
@@ -1,5 +1,8 @@
 #include "cpp-terminal/cursor.hpp"
 
+// C++ libs
+#include <cstdlib> // for integer to string conversions 
+
 Term::Cursor::Cursor(const std::size_t& row, const std::size_t& column) : m_position({row, column}) {}
 
 std::size_t Term::Cursor::row() const { return m_position.first; }
@@ -17,20 +20,68 @@ void Term::Cursor::setRow(const std::size_t& row) { m_position.first = row; }
 
 void Term::Cursor::setColum(const std::size_t& column) { m_position.second = column; }
 
-std::string Term::cursor_off() { return "\x1b[?25l"; }
+void Term::cursor_off(std::string& stringOut) { stringOut.append("\x1b[?25l"); }
 
-std::string Term::cursor_on() { return "\x1b[?25h"; }
+std::string Term::cursor_off() { return std::string("\x1b[?25l"); }
+
+void Term::cursor_on(std::string& stringOut) { stringOut.append("\x1b[?25h"); }
+
+std::string Term::cursor_on() { return std::string("\x1b[?25h"); }
+
+void Term::cursor_move(std::string stringOut&, std::size_t row, std::size_t column) { 	
+	stringOut.append("\x1b[");
+	stringOut.append(std::to_string(row));
+	stringOut.append(';');
+	stringOut.append(std::to_string(column));
+	stringOut.append('H');
+ }
 
 std::string Term::cursor_move(std::size_t row, std::size_t column) { return "\x1b[" + std::to_string(row) + ';' + std::to_string(column) + 'H'; }
 
+
 std::string Term::cursor_up(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'A'; }
+
+void Term::cursor_up(std::string& stringOut, std::size_t rows) { 
+	stringOut.append("\x1b[");
+	stringOut.append(std::to_string(rows));
+	stringOut.append('A');
+}
 
 std::string Term::cursor_down(std::size_t rows) { return "\x1b[" + std::to_string(rows) + 'B'; }
 
+void Term::cursor_down(std::string& stringOut, std::size_t rows) { 
+	stringOut.append("\x1b[");
+	stringOut.append(std::to_string(rows));
+	stringOut.append('B');
+}
+
 std::string Term::cursor_right(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'C'; }
+
+void Term::cursor_right(std::string& stringOut, std::size_t columns) { 
+	stringOut.append("\x1b[");
+	stringOut.append(std::to_string(columns));
+	stringOut.append('C');
+	
+}
 
 std::string Term::cursor_left(std::size_t columns) { return "\x1b[" + std::to_string(columns) + 'D'; }
 
+void Term::cursor_left(std::string& stringOut, std::size_t columns) { 
+	stringOut.append("\x1b[");
+	stringOut.append(std::to_string(columns));
+	stringOut.append('D');
+}
+
 std::string Term::cursor_position_report() { return "\x1b[6n"; }
 
+void Term::cursor_position_report(std::string& stringOut, ) { 
+	stringOut.append("\x1b[6n"); 
+}
+
 std::string Term::clear_eol() { return "\x1b[K"; }
+
+void Term::clear_eol(std::string& stringOut, ) { 
+	stringOut("\x1b[K");
+}
+
+

--- a/cpp-terminal/cursor.hpp
+++ b/cpp-terminal/cursor.hpp
@@ -11,7 +11,7 @@ class Cursor
 {
 public:
   Cursor() = default;
-  Cursor(const std::size_t&, const std::size_t&);
+  Cursor(const std::size_t& row, const std::size_t& column);
   std::size_t row() const;
   std::size_t column() const;
   void        setRow(const std::size_t&);

--- a/cpp-terminal/cursor.hpp
+++ b/cpp-terminal/cursor.hpp
@@ -27,22 +27,38 @@ Term::Cursor cursor_position();
 
 // move the cursor to the given (row, column) / (Y, X)
 std::string cursor_move(std::size_t row, std::size_t column);
+void cursor_move(std::string& stringOut, std::size_t row, std::size_t column);
+
 // move the cursor the given rows up
 std::string cursor_up(std::size_t rows);
+void cursor_up(std::string& stringOut, std::size_t rows);
+
 // move the cursor the given rows down
 std::string cursor_down(std::size_t rows);
+void cursor_down(std::string& stringOut, std::size_t rows);
+
 // move the cursor the given columns left
 std::string cursor_left(std::size_t columns);
+void cursor_left(std::string& stringOut, std::size_t columns);
+
 // move the cursor the given columns right
 std::string cursor_right(std::size_t columns);
+void cursor_right(std::string& stringOut, std::size_t columns);
+
 // the ANSI code to generate a cursor position report
 std::string cursor_position_report();
+void cursor_position_report(std::string& stringOut);
+
 // turn off the cursor
 std::string cursor_off();
+void cursor_off(std::string& stringOut);
+
 // turn on the cursor
 std::string cursor_on();
+void cursor_on(std::string& stringOut);
 
 // clears the screen from the current cursor position to the end of the screen
 std::string clear_eol();
+void clear_eol(std::string& stringOut);
 
 }  // namespace Term


### PR DESCRIPTION
I did not delete any functions or methods (I state that because 'git diff' markes some as deleted but it just did not realise that they only changed lines). I only added functions that unlike the old ones do not create new std::strings but write into an existing one that can be pre-allocated.

This may also be beneficial to the issue  [#186 improve the rendering performance](https://github.com/jupyter-xeus/cpp-terminal/issues/186) by avoiding calls to malloc.

Furthermore I added the variable names 'row' and 'column' to the cursor constructor so that the programmer can quickly see from a look into the header (or the IDEs pop up) which argument belongs to which dimension.