### PR TITLE
Windows unicode

### DIFF
--- a/cpp-terminal/exception.hpp
+++ b/cpp-terminal/exception.hpp
@@ -12,6 +12,7 @@
 #include <exception>
 #include <stdexcept>
 #include <string>
+#include <cstdint>
 
 namespace Term
 {
@@ -20,10 +21,14 @@ class Exception : public std::exception
 {
 public:
   Exception(const std::string& what) : m_what(what) {}
+  Exception(const std::int64_t& code, const std::string& what) : m_what(what), m_code(code) {}
   virtual const char* what() const noexcept override { return m_what.c_str(); }
+  std::int64_t        code() const noexcept { return m_code; }
+  virtual ~Exception() = default;
 
-private:
+protected:
   std::string m_what;
+  std::int64_t m_code{0};
 };
 
 }  // namespace Term

--- a/cpp-terminal/exception.hpp
+++ b/cpp-terminal/exception.hpp
@@ -9,10 +9,10 @@
 
 #pragma once
 
+#include <cstdint>
 #include <exception>
 #include <stdexcept>
 #include <string>
-#include <cstdint>
 
 namespace Term
 {
@@ -27,7 +27,7 @@ public:
   virtual ~Exception() = default;
 
 protected:
-  std::string m_what;
+  std::string  m_what;
   std::int64_t m_code{0};
 };
 

--- a/cpp-terminal/platforms/CMakeLists.txt
+++ b/cpp-terminal/platforms/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(THREADS_PREFER_PTHREAD_FLAG TRUE)
 find_package(Threads)
-add_library(cpp-terminal-platforms STATIC conversion.cpp args.cpp terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp file.cpp env.cpp blocking_queue.cpp sigwinch.cpp)
+add_library(cpp-terminal-platforms STATIC exception.cpp unicode.cpp conversion.cpp args.cpp terminal.cpp tty.cpp terminfo.cpp input.cpp screen.cpp cursor.cpp file.cpp env.cpp blocking_queue.cpp sigwinch.cpp)
 target_link_libraries(cpp-terminal-platforms PRIVATE Warnings::Warnings PUBLIC Threads::Threads)
 target_compile_options(cpp-terminal-platforms PRIVATE $<$<CXX_COMPILER_ID:MSVC>:/utf-8 /wd4668 /wd4514>)
 target_include_directories(cpp-terminal-platforms PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}> $<INSTALL_INTERFACE:include>)

--- a/cpp-terminal/platforms/args.cpp
+++ b/cpp-terminal/platforms/args.cpp
@@ -9,13 +9,12 @@
 
 #include "cpp-terminal/args.hpp"
 
-#include "cpp-terminal/platforms/conversion.hpp"
-
 #if defined(_WIN32)
   #include <memory>
 // clang-format off
   #include <windows.h>
   #include <processenv.h>
+  #include "cpp-terminal/platforms/unicode.hpp"
 // clang-format on
 #elif defined(__APPLE__)
   #include <crt_externs.h>
@@ -39,7 +38,7 @@ void Term::Arguments::parse()
   else
   {
     m_args.reserve(static_cast<std::size_t>(argc));
-    for(std::size_t i = 0; i != static_cast<std::size_t>(argc); ++i) { m_args.push_back(Term::Private::to_utf8(&wargv.get()[i][0])); }
+    for(std::size_t i = 0; i != static_cast<std::size_t>(argc); ++i) { m_args.push_back(Term::Private::to_narrow(&wargv.get()[i][0])); }
     m_parsed = true;
   }
 #elif defined(__APPLE__)

--- a/cpp-terminal/platforms/conversion.cpp
+++ b/cpp-terminal/platforms/conversion.cpp
@@ -11,24 +11,10 @@
 
 #include "cpp-terminal/exception.hpp"
 
-#if defined(_WIN32)
-  #include <windows.h>
-#endif
-
 namespace Term
 {
 namespace Private
 {
-
-#if defined(_WIN32)
-std::string to_utf8(LPCWCH utf16Str)
-{
-  int         size_needed{WideCharToMultiByte(CP_UTF8, 0, utf16Str, -1, nullptr, 0, nullptr, nullptr)};
-  std::string ret(static_cast<std::size_t>(size_needed), '\0');
-  WideCharToMultiByte(CP_UTF8, 0, utf16Str, static_cast<int>(wcslen(utf16Str)), &ret[0], size_needed, nullptr, nullptr);
-  return ret.c_str();
-}
-#endif
 
 static constexpr std::uint8_t UTF8_ACCEPT{0};
 static constexpr std::uint8_t UTF8_REJECT{0xf};

--- a/cpp-terminal/platforms/conversion.hpp
+++ b/cpp-terminal/platforms/conversion.hpp
@@ -13,20 +13,10 @@
 #include <string>
 #include <vector>
 
-#if __cplusplus >= 201703L
-  #define TERM_CONSTEXPR constexpr
-#else
-  #define TERM_CONSTEXPR
-#endif
-
 namespace Term
 {
 namespace Private
 {
-
-#if defined(_WIN32)
-std::string to_utf8(const wchar_t* utf16Str);
-#endif
 
 std::uint8_t utf8_decode_step(std::uint8_t state, std::uint8_t octet, std::uint32_t* cpp);
 
@@ -38,117 +28,6 @@ std::string utf32_to_utf8(const std::u32string& s);
 
 bool is_valid_utf8_code_unit(const std::string& s);
 
-enum class Identifier : std::int8_t
-{
-  Unsupported = -1,
-  NotFirst    = 0,
-  Bytes1      = 1,
-  Bytes2      = 2,
-  Bytes3      = 3,
-  Bytes4      = 4
-};
-
-/// returns the length of the utf8 sequence if it is the first character
-/// returns '0' if it is a character in the sequence but not the first one
-/// returns '-1' if it is an unsupported character by the utf8 standard
-TERM_CONSTEXPR inline Identifier identify(char c)
-{
-  const auto       prefix = (c & 0xF8) >> 3;
-  const Identifier lookupTable[32]{
-    /*00000*/ Identifier::Bytes1,
-    /*00001*/ Identifier::Bytes1,
-    /*00010*/ Identifier::Bytes1,
-    /*00011*/ Identifier::Bytes1,
-    /*00100*/ Identifier::Bytes1,
-    /*00101*/ Identifier::Bytes1,
-    /*00110*/ Identifier::Bytes1,
-    /*00111*/ Identifier::Bytes1,
-    /*01000*/ Identifier::Bytes1,
-    /*01001*/ Identifier::Bytes1,
-    /*01010*/ Identifier::Bytes1,
-    /*01011*/ Identifier::Bytes1,
-    /*01100*/ Identifier::Bytes1,
-    /*01101*/ Identifier::Bytes1,
-    /*01110*/ Identifier::Bytes1,
-    /*01111*/ Identifier::Bytes1,
-
-    /*10000*/ Identifier::NotFirst,
-    /*10001*/ Identifier::NotFirst,
-    /*10010*/ Identifier::NotFirst,
-    /*10011*/ Identifier::NotFirst,
-    /*10100*/ Identifier::NotFirst,
-    /*10101*/ Identifier::NotFirst,
-    /*10110*/ Identifier::NotFirst,
-    /*10111*/ Identifier::NotFirst,
-    /*11000*/ Identifier::Bytes2,
-    /*11001*/ Identifier::Bytes2,
-    /*11010*/ Identifier::Bytes2,
-    /*11011*/ Identifier::Bytes2,
-    /*11100*/ Identifier::Bytes3,
-    /*11101*/ Identifier::Bytes3,
-    /*11110*/ Identifier::Bytes4,
-    /*11111*/ Identifier::Unsupported,
-  };
-  return lookupTable[prefix];
-}
-
 }  // namespace Private
 
-// given a range [first, last) this function will parse the first utf8 character and writes it 'out'.
-// if 'first' points to a correct utf8 symbol then the function will return a pointer to then next symbol
-// if 'first' does not point to a correct utf8 symbol or the symbol would extend over 'last' then the function returns 'first'
-template<class CharItr> TERM_CONSTEXPR CharItr utf8_to_utf32(const CharItr first, const CharItr last, std::int32_t* out)
-{
-  const Private::Identifier id = Private::identify(*first);
-  switch(id)
-  {
-    case Private::Identifier::Bytes1:
-      if(std::distance(first, last) >= 1)
-      {
-        *out = static_cast<std::int32_t>(first[0]);
-        return first + 1;
-      }
-
-      break;
-    case Private::Identifier::Bytes2:
-      if(std::distance(first, last) >= 2)
-      {
-        if((first[1] & 0xC0) == 0xC0)
-        {
-          *out = (static_cast<std::int32_t>(first[0] & 0x1F) << 6) | static_cast<std::int32_t>(first[1] & 0x3F);
-          return first + 2;
-        }
-      }
-
-      break;
-    case Private::Identifier::Bytes3:
-      if(std::distance(first, last) >= 3)
-      {
-        if((first[1] & 0xC0) == 0xC0 && (first[2] & 0xC0) == 0xC0)
-        {
-          *out = (static_cast<std::int32_t>(first[0] & 0x0F) << 12) | (static_cast<std::int32_t>(first[1] & 0x3F) << 6) | (static_cast<std::int32_t>(first[2] & 0x3F));
-          return first + 3;
-        }
-      }
-
-      break;
-    case Private::Identifier::Bytes4:
-      if(std::distance(first, last) >= 4)
-      {
-        if((first[1] & 0xC0) == 0xC0 && (first[2] & 0xC0) == 0xC0 && (first[3] & 0xC0) == 0xC0)
-        {
-          *out = (static_cast<std::int32_t>(first[0] & 0x07) << 24) | (static_cast<std::int32_t>(first[1] & 0x3F) << 12) | (static_cast<std::int32_t>(first[2] & 0x3F) << 6) | (static_cast<std::int32_t>(first[3] & 0x3F));
-          return first + 4;
-        }
-      }
-
-      break;
-    case Private::Identifier::Unsupported: break; break;
-    default: break;
-  }
-  return first;
-}
-
 }  // namespace Term
-
-#undef TERM_CONSTEXPR

--- a/cpp-terminal/platforms/env.cpp
+++ b/cpp-terminal/platforms/env.cpp
@@ -9,18 +9,20 @@
 
 #include "cpp-terminal/platforms/env.hpp"
 
-std::pair<bool, std::string> Term::Private::getenv(const std::string& env)
+#include "cpp-terminal/platforms/unicode.hpp"
+
+std::pair<bool, std::string> Term::Private::getenv(const std::string& key)
 {
-#ifdef _WIN32
-  std::size_t requiredSize{0};
-  getenv_s(&requiredSize, nullptr, 0, env.c_str());
-  if(requiredSize == 0) return {false, std::string()};
-  std::string ret;
-  ret.reserve(requiredSize * sizeof(char));
-  getenv_s(&requiredSize, &ret[0], requiredSize, env.c_str());
-  return {true, ret};
+#if defined(_WIN32)
+  std::size_t size{0};
+  _wgetenv_s(&size, nullptr, 0, Term::Private::to_wide(key).c_str());
+  std::wstring ret;
+  if(size == 0 || size > ret.max_size()) return {false, std::string()};
+  ret.reserve(size);
+  _wgetenv_s(&size, &ret[0], size, Term::Private::to_wide(key).c_str());
+  return {true, Term::Private::to_narrow(ret)};
 #else
-  if(std::getenv(env.c_str()) != nullptr) return {true, static_cast<std::string>(std::getenv(env.c_str()))};
+  if(std::getenv(key.c_str()) != nullptr) return {true, static_cast<std::string>(std::getenv(key.c_str()))};
   else
     return {false, std::string()};
 #endif

--- a/cpp-terminal/platforms/exception.cpp
+++ b/cpp-terminal/platforms/exception.cpp
@@ -1,0 +1,40 @@
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#include "cpp-terminal/platforms/exception.hpp"
+
+#include "cpp-terminal/platforms/unicode.hpp"
+
+#if defined(_WIN32)
+  #include <memory>
+  #include <windows.h>
+#endif
+
+#include <iostream>
+
+#if defined(_WIN32)
+Term::Private::WindowsError::WindowsError(const unsigned long& error) : Term::Exception(static_cast<std::int64_t>(error), "")
+{
+  wchar_t*    ptr{nullptr};
+  const DWORD cchMsg{FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_ALLOCATE_BUFFER, nullptr, static_cast<uint32_t>(m_code), 0, reinterpret_cast<wchar_t*>(&ptr), 0, nullptr)};
+  if(cchMsg > 0)
+  {
+    auto deleter = [](void* p)
+    {
+      if(p != nullptr) { ::LocalFree(p); }
+    };
+    std::unique_ptr<wchar_t, decltype(deleter)> ptrBuffer(ptr, deleter);
+    std::string                                 ret{Term::Private::to_narrow(ptrBuffer.get())};
+    if(ret.size() >= 2 && ret[ret.size() - 1] == '\n' && ret[ret.size() - 2] == '\r') ret.erase(ret.size() - 2);
+    m_what = ret;
+  }
+  else { throw Term::Exception(::GetLastError(), "Error in FormatMessageW"); }
+}
+
+#endif

--- a/cpp-terminal/platforms/exception.hpp
+++ b/cpp-terminal/platforms/exception.hpp
@@ -1,0 +1,30 @@
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#include "cpp-terminal/exception.hpp"
+
+namespace Term
+{
+
+namespace Private
+{
+
+// Helper for windows errors
+#if defined(_WIN32)
+class WindowsError : public Term::Exception
+{
+public:
+  WindowsError(const unsigned long& error);
+  virtual ~WindowsError() = default;
+};
+#endif
+
+}  // namespace Private
+
+}  // namespace Term

--- a/cpp-terminal/platforms/input.cpp
+++ b/cpp-terminal/platforms/input.cpp
@@ -8,7 +8,7 @@
 */
 
 #if defined(_WIN32)
-  #include "cpp-terminal/platforms/conversion.hpp"
+  #include "cpp-terminal/platforms/unicode.hpp"
 
   #include <vector>
   #include <windows.h>
@@ -68,7 +68,7 @@ void sendString(Term::Private::BlockingQueue& events, std::wstring& str)
 {
   if(!str.empty())
   {
-    events.push(Term::Event(Term::Private::to_utf8(str.c_str())));
+    events.push(Term::Event(Term::Private::to_narrow(str.c_str())));
     str.clear();
   }
 }

--- a/cpp-terminal/platforms/unicode.cpp
+++ b/cpp-terminal/platforms/unicode.cpp
@@ -1,0 +1,47 @@
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#include "cpp-terminal/platforms/unicode.hpp"
+
+#include "cpp-terminal/platforms/exception.hpp"
+
+#if defined(_WIN32)
+  #include <windows.h>
+#endif
+
+#if defined(_WIN32)
+std::string Term::Private::to_narrow(const std::wstring& in)
+{
+  if(in.empty()) return std::string();
+  static constexpr DWORD flag{WC_ERR_INVALID_CHARS};
+  std::size_t            in_size{in.size()};
+  if(in_size > static_cast<size_t>((std::numeric_limits<int>::max)())) throw Term::Exception("String size is to big " + std::to_string(in_size) + "/" + std::to_string((std::numeric_limits<int>::max)()));
+  const int ret_size{::WideCharToMultiByte(CP_UTF8, flag, in.data(), static_cast<int>(in_size), nullptr, 0, nullptr, nullptr)};
+  if(ret_size == 0) throw Term::Private::WindowsError(::GetLastError());
+  std::string ret(static_cast<std::size_t>(ret_size), '\0');
+  int         ret_error{::WideCharToMultiByte(CP_UTF8, flag, in.data(), static_cast<int>(in_size), &ret[0], ret_size, nullptr, nullptr)};
+  if(ret_error == 0) throw Term::Private::WindowsError(::GetLastError());
+  return ret;
+}
+
+std::wstring Term::Private::to_wide(const std::string& in)
+{
+  if(in.empty()) return std::wstring();
+  static constexpr DWORD flag{MB_ERR_INVALID_CHARS};
+  std::size_t            in_size{in.size()};
+  if(in_size > static_cast<size_t>((std::numeric_limits<int>::max)())) throw Term::Exception("String size is to big " + std::to_string(in_size) + "/" + std::to_string((std::numeric_limits<int>::max)()));
+  const int ret_size{::MultiByteToWideChar(CP_UTF8, flag, in.data(), static_cast<int>(in_size), nullptr, 0)};
+  if(ret_size == 0) throw Term::Private::WindowsError(::GetLastError());
+  std::wstring ret(static_cast<std::size_t>(ret_size), '\0');
+  int          ret_error{::MultiByteToWideChar(CP_UTF8, flag, in.data(), static_cast<int>(in_size), &ret[0], ret_size)};
+  if(ret_error == 0) throw Term::Private::WindowsError(::GetLastError());
+  return ret;
+}
+
+#endif

--- a/cpp-terminal/platforms/unicode.cpp
+++ b/cpp-terminal/platforms/unicode.cpp
@@ -12,6 +12,7 @@
 #include "cpp-terminal/platforms/exception.hpp"
 
 #if defined(_WIN32)
+  #include <limits>
   #include <windows.h>
 #endif
 

--- a/cpp-terminal/platforms/unicode.cpp
+++ b/cpp-terminal/platforms/unicode.cpp
@@ -43,5 +43,4 @@ std::wstring Term::Private::to_wide(const std::string& in)
   if(ret_error == 0) throw Term::Private::WindowsError(::GetLastError());
   return ret;
 }
-
 #endif

--- a/cpp-terminal/platforms/unicode.hpp
+++ b/cpp-terminal/platforms/unicode.hpp
@@ -1,0 +1,26 @@
+
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#pragma once
+
+#include <string>
+
+namespace Term
+{
+namespace Private
+{
+
+// utf16 is useless and wstring too so utf16 inside wstring is useless^2 but windows use it so define this functions to deal with it and less the user forget it.
+#if defined(_WIN32)
+std::string  to_narrow(const std::wstring& wstr);
+std::wstring to_wide(const std::string& str);
+#endif
+}  // namespace Private
+}  // namespace Term

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,8 +3,8 @@ add_library(ExamplesWarnings INTERFACE)
 target_compile_options(
         ExamplesWarnings
         INTERFACE
-        $<$<C_COMPILER_ID:MSVC>:/wd4061 /utf-8>
-        $<$<CXX_COMPILER_ID:MSVC>:/wd4061 /utf-8>
+        $<$<C_COMPILER_ID:MSVC>:/wd4061 /utf-8 /wd4668>
+        $<$<CXX_COMPILER_ID:MSVC>:/wd4061 /utf-8 /wd4668>
 )
 add_library(Warnings::Examples ALIAS ExamplesWarnings)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,3 +50,11 @@ add_executable(Args args.test.cpp)
 target_link_libraries(Args PRIVATE doctest::doctest cpp-terminal::cpp-terminal)
 doctest_discover_tests(Args EXTRA_ARGS Bonjour Hello 你好)
 endif()
+
+add_executable(exception exception.test.cpp)
+target_link_libraries(exception PRIVATE doctest::doctest cpp-terminal::cpp-terminal)
+doctest_discover_tests(exception)
+
+add_executable(unicode unicode.test.cpp)
+target_link_libraries(unicode PRIVATE doctest::doctest cpp-terminal::cpp-terminal)
+doctest_discover_tests(unicode)

--- a/tests/exception.test.cpp
+++ b/tests/exception.test.cpp
@@ -21,6 +21,5 @@ TEST_CASE("WindowsError")
   Term::Private::WindowsError error(1);
   std::string                 ret{error.what()};
   CHECK(error.code() == 1);
-  CHECK((std::string(error.what()) == std::string(u8"Incorrect function.")) || (std::string(error.what()) == std::string(u8"Invalid function.")));  // In some windows the message is different :(
 }
 #endif

--- a/tests/exception.test.cpp
+++ b/tests/exception.test.cpp
@@ -21,6 +21,6 @@ TEST_CASE("WindowsError")
   Term::Private::WindowsError error(1);
   std::string                 ret{error.what()};
   CHECK(error.code() == 1);
-  CHECK(std::string(error.what()) == u8"Incorrect function.");
+  CHECK(std::string(error.what()) == std::string(u8"Incorrect function."));
 }
 #endif

--- a/tests/exception.test.cpp
+++ b/tests/exception.test.cpp
@@ -21,6 +21,6 @@ TEST_CASE("WindowsError")
   Term::Private::WindowsError error(1);
   std::string                 ret{error.what()};
   CHECK(error.code() == 1);
-  CHECK(std::string(error.what()) == std::string(u8"Incorrect function."));
+  CHECK((std::string(error.what()) == std::string(u8"Incorrect function.")) || (std::string(error.what()) == std::string(u8"Invalid function.")));  // In some windows the message is different :(
 }
 #endif

--- a/tests/exception.test.cpp
+++ b/tests/exception.test.cpp
@@ -1,0 +1,26 @@
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#define DOCTEST_CONFIG_USE_STD_HEADERS
+#include "cpp-terminal/platforms/exception.hpp"
+
+#include "doctest/doctest.h"
+
+#include <iostream>
+
+#if defined(_WIN32)
+TEST_CASE("WindowsError")
+{
+  Term::Private::WindowsError error(1);
+  std::string                 ret{error.what()};
+  CHECK(error.code() == 1);
+  CHECK(std::string(error.what()) == u8"Incorrect function.");
+}
+#endif

--- a/tests/unicode.test.cpp
+++ b/tests/unicode.test.cpp
@@ -1,0 +1,33 @@
+/*
+* cpp-terminal
+* C++ library for writing multiplatform terminal applications.
+*
+* SPDX-FileCopyrightText: 2019-2023 cpp-terminal
+*
+* SPDX-License-Identifier: MIT
+*/
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "cpp-terminal/platforms/unicode.hpp"
+
+#include "doctest/doctest.h"
+
+#include <string>
+
+#if defined(_WIN32)
+TEST_CASE("to_narrow")
+{
+  std::wstring in(L"Hello World; 你好; おはようございます; בוקר טוב");
+  std::string  out{Term::Private::to_narrow(in)};
+  CHECK(out == u8"Hello World; 你好; おはようございます; בוקר טוב");
+}
+#endif
+
+#if defined(_WIN32)
+TEST_CASE("to_wide")
+{
+  std::string in(u8"∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)γνωρίζω ἀπὸ τὴν ὄψηდარგებში⠝⠁⠊⠇ ⠁⠎ ⠹⠑ ⠙როგორიცააᚻ∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂᛖᛒᚢᛞᛖразличных\tопеฮั่นเสื่อมโทรมแማደሪያ የለው፥ ግንድ ይዞ ይዞራል።\n");  // Some multi-language charabia
+  std::wstring out{Term::Private::to_wide(in)};
+  CHECK(out == L"∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)γνωρίζω ἀπὸ τὴν ὄψηდარგებში⠝⠁⠊⠇ ⠁⠎ ⠹⠑ ⠙როგორიცააᚻ∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂᛖᛒᚢᛞᛖразличных\tопеฮั่นเสื่อมโทรมแማደሪያ የለው፥ ግንድ ይዞ ይዞራል።\n");
+}
+#endif

--- a/tests/unicode.test.cpp
+++ b/tests/unicode.test.cpp
@@ -19,7 +19,7 @@ TEST_CASE("to_narrow")
 {
   std::wstring in(L"Hello World; 你好; おはようございます; בוקר טוב");
   std::string  out{Term::Private::to_narrow(in)};
-  CHECK(out == u8"Hello World; 你好; おはようございます; בוקר טוב");
+  CHECK(out == std::string(u8"Hello World; 你好; おはようございます; בוקר טוב"));
 }
 #endif
 

--- a/tests/unicode.test.cpp
+++ b/tests/unicode.test.cpp
@@ -19,14 +19,14 @@ TEST_CASE("to_narrow")
 {
   std::wstring in(L"Hello World; 你好; おはようございます; בוקר טוב");
   std::string  out{Term::Private::to_narrow(in)};
-  CHECK(out == std::string(u8"Hello World; 你好; おはようございます; בוקר טוב"));
+  CHECK(out == (const char*)(u8"Hello World; 你好; おはようございます; בוקר טוב"));
 }
 #endif
 
 #if defined(_WIN32)
 TEST_CASE("to_wide")
 {
-  std::string in(u8"∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)γνωρίζω ἀπὸ τὴν ὄψηდარგებში⠝⠁⠊⠇ ⠁⠎ ⠹⠑ ⠙როგორიცააᚻ∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂᛖᛒᚢᛞᛖразличных\tопеฮั่นเสื่อมโทรมแማደሪያ የለው፥ ግንድ ይዞ ይዞራል።\n");  // Some multi-language charabia
+  std::string in((const char*)(u8"∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)γνωρίζω ἀπὸ τὴν ὄψηდარგებში⠝⠁⠊⠇ ⠁⠎ ⠹⠑ ⠙როგორიცააᚻ∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂᛖᛒᚢᛞᛖразличных\tопеฮั่นเสื่อมโทรมแማደሪያ የለው፥ ግንድ ይዞ ይዞራል።\n"));  // Some multi-language charabia
   std::wstring out{Term::Private::to_wide(in)};
   CHECK(out == L"∮ E⋅da = Q,  n → ∞, ∑ f(i) = ∏ g(i)γνωρίζω ἀπὸ τὴν ὄψηდარგებში⠝⠁⠊⠇ ⠁⠎ ⠹⠑ ⠙როგორიცააᚻ∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂᛖᛒᚢᛞᛖразличных\tопеฮั่นเสื่อมโทรมแማደሪያ የለው፥ ግንድ ይዞ ይዞራል።\n");
 }


### PR DESCRIPTION
`Windows` use UNICODE (`wchar_t` in `utf16`), this PR add a better narrow<->wide converter only for Windows as utf16 is useless on other OS. I added special `WindowsError` exception too to be able to get the string corresponding to `GetLastError()` (converted to utf8 of course). This will allow to have better exceptions on windows without too much trouble. I expect to have one for `errno` too