### PR TITLE
Fix Clang 17

### DIFF
--- a/cpp-terminal/iostream.cpp
+++ b/cpp-terminal/iostream.cpp
@@ -16,7 +16,7 @@ namespace
 std::array<char, sizeof(Term::TOstream)> cout_buffer;  //NOLINT(fuchsia-statically-constructed-objects)
 std::array<char, sizeof(Term::TOstream)> clog_buffer;  //NOLINT(fuchsia-statically-constructed-objects)
 std::array<char, sizeof(Term::TOstream)> cerr_buffer;  //NOLINT(fuchsia-statically-constructed-objects)
-std::array<char, sizeof(Term::TOstream)> cin_buffer;   //NOLINT(fuchsia-statically-constructed-objects)
+std::array<char, sizeof(Term::TIstream)> cin_buffer;   //NOLINT(fuchsia-statically-constructed-objects)
 }  // namespace
 
 Term::TOstream& Term::cout = reinterpret_cast<Term::TOstream&>(cout_buffer);  //NOLINT(cppcoreguidelines-pro-type-reinterpret-cast)


### PR DESCRIPTION
I was getting segmentation faults for every example after building with Clang 17.0.6 and after further investigation it seems that the only issue was a typo in the size of the cin_buffer.