### PR TITLE
fix: initialize `Term::Button::Type type` to resolve uninitialized variable exception in event.cpp

### DIFF
--- a/cpp-terminal/event.cpp
+++ b/cpp-terminal/event.cpp
@@ -260,7 +260,7 @@ void Term::Event::parse(const std::string& str)
     if(str[str.size() - 1] == 'm') action = Term::Button::Action::Released;
     else
       action = Term::Button::Action::Pressed;
-    Term::Button::Type type;
+    Term::Button::Type type = Button::Type::None;
     switch(values[0])
     {
       case 0:


### PR DESCRIPTION
### Problem:
In **Windows Terminal** on **Windows 11**, using **CTRL+ Mouse Scroll🖱️** was causing the following exception: `Exception has occurred: The variable 'type' is being used without being initialized.`

<img src="https://github.com/user-attachments/assets/d32f7f2b-53e7-418a-a956-7783d29acdb0" width="400" />



This occurred because the `Term::Button::Type type` variable was accessed without being properly initialized during the event handling.

### Solution:
The `type` variable has been explicitly initialized to `Button::Type::None`, ensuring that it has a valid default value before being accessed. This prevents the uninitialized variable exception.

### Impact:
This fix resolves the exception triggered by  **CTRL+ Mouse Scroll🖱️** in Windows Terminal, allowing the event to be processed without errors.

### ⚠️ Warning (Zoom not working):
While this fix resolves the crash, zooming with  **CTRL+ Mouse Scroll🖱️** is still not functional. (Different of **CTRL+** or **CTRL-**)

 This PR does not address the zoom functionality.

