### PR TITLE
Fix issue with multiline prompts jumping

### DIFF
--- a/cpp-terminal/prompt.cpp
+++ b/cpp-terminal/prompt.cpp
@@ -356,7 +356,7 @@ std::string Term::prompt_multiline(const std::string& prompt_string, std::vector
     }
     render(scr, model, screen.columns());
     std::cout << scr.render(1, cursor.row(), term_attached) << std::flush;
-    if(cursor.row() + scr.columns() - 1 > screen.rows())
+    if(cursor.row() + scr.rows() - 1 > screen.rows())
     {
       cursor = Cursor({Row(static_cast<std::uint16_t>(screen.rows() - (scr.columns() - 1))), Column(cursor.column())});
       std::cout << scr.render(1, cursor.row(), term_attached) << std::flush;


### PR DESCRIPTION
Seems to address #404.

For the record - I have no idea what I'm doing in this repo, I just noticed that this was comparing rows to columns and it appears to fix it, it's entirely possible that this isn't the right fix.

Also - does something like this warrant a test?

